### PR TITLE
Feature/merge qdrant collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ alembic upgrade head
 Assuming you want to ingest corpus "wikipedia" and "PLOS" in english and french for the first one and only in english for the second one.
 You're using **all-minilm-l6-v2** vectorizer for english and **sentence-camembert-base** for the french.
 You need to create the following collections in qdrant:
-- collection_wikipedia_en_all-minilm-l6-v2_v0
-- collection_wikipedia_fr_sentence-camembert-base_v0
-- collection_plos_en_all-minilm-l6-v2_v0
+- collection_welearn_en_all-minilm-l6-v2_v0
+- collection_welearn_fr_sentence-camembert-base_v0
+
+And for retrieving data from specific corpus you must use the `document_corpus` in payload field as it's written in [qdrant documentation](https://qdrant.tech/documentation/guides/multiple-partitions/).
 
 Command for [create collection](https://qdrant.tech/documentation/concepts/collections/#create-a-collection) :
 ```

--- a/tests/qdrant_syncronizer/test_qdrant_handler.py
+++ b/tests/qdrant_syncronizer/test_qdrant_handler.py
@@ -59,14 +59,14 @@ class TestQdrantHandler(unittest.TestCase):
         self.client = QdrantClient(":memory:")
 
         self.client.create_collection(
-            collection_name="collection_en_embmodel",
+            collection_name="collection_welearn_en_embmodel",
             vectors_config=models.VectorParams(
                 size=50, distance=models.Distance.COSINE
             ),
         )
 
         self.client.create_collection(
-            collection_name="collection_fr_embmodel",
+            collection_name="collection_welearn_fr_embmodel",
             vectors_config=models.VectorParams(
                 size=50, distance=models.Distance.COSINE
             ),
@@ -83,7 +83,7 @@ class TestQdrantHandler(unittest.TestCase):
         slices = [fake_slice]
         collections_names = classify_documents_per_collection(qdrant_connector, slices)
 
-        expected = {"collection_en_embmodel": {fake_slice.document_id}}
+        expected = {"collection_welearn_en_embmodel": {fake_slice.document_id}}
         self.assertEqual(collections_names, expected)
 
     def test_should_handle_multiple_slices_for_same_collection(self):
@@ -101,7 +101,7 @@ class TestQdrantHandler(unittest.TestCase):
         slices = [fake_slice0, fake_slice1, fake_slice2]
         collections_names = classify_documents_per_collection(qdrant_connector, slices)
         expected = {
-            "collection_en_embmodel": {doc_id0},
-            "collection_fr_embmodel": {doc_id1},
+            "collection_welearn_en_embmodel": {doc_id0},
+            "collection_welearn_fr_embmodel": {doc_id1},
         }
         self.assertEqual(collections_names, expected)

--- a/tests/qdrant_syncronizer/test_qdrant_syncronizer.py
+++ b/tests/qdrant_syncronizer/test_qdrant_syncronizer.py
@@ -34,12 +34,12 @@ class TestQdrantSyncronizer(unittest.TestCase):
         self.client = QdrantClient(":memory:")
 
         self.client.create_collection(
-            collection_name="collection_en_embmodel",
+            collection_name="collection_welearn_en_embmodel",
             vectors_config=models.VectorParams(size=5, distance=models.Distance.COSINE),
         )
 
         self.client.create_collection(
-            collection_name="collection_fr_embmodel",
+            collection_name="collection_welearn_fr_embmodel",
             vectors_config=models.VectorParams(size=5, distance=models.Distance.COSINE),
         )
 
@@ -196,7 +196,7 @@ class TestQdrantSyncronizer(unittest.TestCase):
         self.assertEqual(Step.DOCUMENT_IN_QDRANT.value, most_recent_state.title)
 
         ret_values_from_qdrant = self.client.scroll(
-            collection_name=f"collection_en_embmodel",
+            collection_name=f"collection_welearn_en_embmodel",
             limit=100,
             with_vectors=True,
         )

--- a/tests/qdrant_syncronizer/test_qdrant_syncronizer.py
+++ b/tests/qdrant_syncronizer/test_qdrant_syncronizer.py
@@ -34,22 +34,12 @@ class TestQdrantSyncronizer(unittest.TestCase):
         self.client = QdrantClient(":memory:")
 
         self.client.create_collection(
-            collection_name="collection_corpus_en_embmodel_v0",
+            collection_name="collection_en_embmodel",
             vectors_config=models.VectorParams(size=5, distance=models.Distance.COSINE),
         )
 
         self.client.create_collection(
-            collection_name="collection_corpus_en_embmodel_v1",
-            vectors_config=models.VectorParams(size=5, distance=models.Distance.COSINE),
-        )
-
-        self.client.create_collection(
-            collection_name="collection_corpus_fr_embmodel_v1",
-            vectors_config=models.VectorParams(size=5, distance=models.Distance.COSINE),
-        )
-
-        self.client.create_collection(
-            collection_name="collection_corpus_en_embmodel_v2",
+            collection_name="collection_fr_embmodel",
             vectors_config=models.VectorParams(size=5, distance=models.Distance.COSINE),
         )
 
@@ -205,15 +195,8 @@ class TestQdrantSyncronizer(unittest.TestCase):
 
         self.assertEqual(Step.DOCUMENT_IN_QDRANT.value, most_recent_state.title)
 
-        for i in range(0, 2):
-            ret_values_from_qdrant = self.client.scroll(
-                collection_name=f"collection_corpus_en_embmodel_v{i}", limit=100
-            )
-
-            self.assertEqual(0, len(ret_values_from_qdrant[0]))
-
         ret_values_from_qdrant = self.client.scroll(
-            collection_name=f"collection_corpus_en_embmodel_v2",
+            collection_name=f"collection_en_embmodel",
             limit=100,
             with_vectors=True,
         )

--- a/welearn_datastack/modules/qdrant_handler.py
+++ b/welearn_datastack/modules/qdrant_handler.py
@@ -18,53 +18,6 @@ from welearn_datastack.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-def extract_version_number(collection_name: str) -> int:
-    """
-    Extracts the version number from a collection name
-    :param collection_name: Name of the collection
-    :return: Version number
-    """
-    splitted_infos = collection_name.split("_")
-    version = splitted_infos[-1]
-    try:
-        version_number = int(version.replace("v", ""))
-    except ValueError:
-        raise VersionNumberError(
-            f"Invalid version number, must be an integer: {version}"
-        )
-    return version_number
-
-
-@cache
-def get_last_collection_version(
-    collection_name_first_part: str, qdrant_connector: QdrantClient
-) -> int:
-    """
-    Returns the last version number of a collection in Qdrant.
-    :param collection_name_first_part: Collection name apart the version number
-    -> "collection_{corpus_name.lower()}_{lang_code.lower()}_{embedding_model_name.lower()}"
-    :param qdrant_connector: Qdrant client
-    :return: Higher number of version in db
-    """
-    db_collections_names = qdrant_connector.get_collections().collections
-    filtered = [
-        c.name
-        for c in db_collections_names
-        if c.name.startswith(collection_name_first_part)
-    ]
-
-    if not filtered:
-        # Case there is no old collection
-        logger.exception(
-            "No previous collection found for : %s", collection_name_first_part
-        )
-        raise NoPreviousCollectionError("No previous collection found")
-
-    versions: List[int] = [extract_version_number(c) for c in filtered]
-
-    return max(versions)
-
-
 def classify_documents_per_collection(
     qdrant_connector: QdrantClient, slices: Collection[Type[DocumentSlice]]
 ) -> Dict[str, Set[UUID]]:
@@ -83,13 +36,10 @@ def classify_documents_per_collection(
 
     ret: Dict[str, Set[UUID]] = {}
     for dslice in slices:
-        corpus = dslice.document.corpus.source_name.lower()
         lang = dslice.document.lang
         model = dslice.embedding_model_name
-        first_part = f"collection_{corpus}_{lang}_{model.lower()}"
+        collection_name = f"collection_{lang}_{model.lower()}"
 
-        version_number = get_last_collection_version(first_part, qdrant_connector)
-        collection_name = f"{first_part}_v{version_number}"
         if collection_name not in collections_names_in_qdrant:
             logger.error(
                 "Collection %s not found in Qdrant, slice %s ignored",

--- a/welearn_datastack/modules/qdrant_handler.py
+++ b/welearn_datastack/modules/qdrant_handler.py
@@ -38,7 +38,7 @@ def classify_documents_per_collection(
     for dslice in slices:
         lang = dslice.document.lang
         model = dslice.embedding_model_name
-        collection_name = f"collection_{lang}_{model.lower()}"
+        collection_name = f"collection_welearn_{lang}_{model.lower()}"
 
         if collection_name not in collections_names_in_qdrant:
             logger.error(

--- a/welearn_datastack/nodes_workflow/QdrantSyncronizer/qdrant_syncronizer.py
+++ b/welearn_datastack/nodes_workflow/QdrantSyncronizer/qdrant_syncronizer.py
@@ -94,7 +94,7 @@ def main() -> None:
     for i, chunk in enumerate(qdrant_chunk):
         logger.info("Processing chunk: #%s", i)
         slices: Sequence[Type[DocumentSlice]] = (
-            db_session.query(DocumentSlice)
+            db_session.query(DocumentSlice)  # type: ignore
             .filter(DocumentSlice.document_id.in_(chunk))
             .all()
         )
@@ -144,7 +144,7 @@ def main() -> None:
                     document_slices = slices_per_doc[docid]
                     slices_sdgs = retrieve_slices_sdgs(db_session, document_slices)
                     all_document_sdgs = [
-                        slices_sdgs[s.id]
+                        slices_sdgs[s.id]  # type: ignore
                         for s in document_slices
                         if s.id in slices_sdgs
                     ]
@@ -158,7 +158,7 @@ def main() -> None:
                                 convert_slice_in_qdrant_point(
                                     slice_to_convert=doc_slice,
                                     document_sdgs=accurate_sdgs,
-                                    slice_sdg=slices_sdgs[doc_slice.id],
+                                    slice_sdg=slices_sdgs[doc_slice.id],  # type: ignore
                                 )
                             )
 


### PR DESCRIPTION
This pull request includes changes to simplify the Qdrant synchronization process by removing versioning logic, updating collection naming conventions, and cleaning up unused code. The changes also include minor type hint adjustments for better code clarity.

### Simplification of Qdrant Synchronization Logic:
* Removed versioning logic from `welearn_datastack/modules/qdrant_handler.py`, including the `extract_version_number` and `get_last_collection_version` functions, and updated `classify_documents_per_collection` to use static collection names without version suffixes. [[1]](diffhunk://#diff-f325d021297cc196321fcff0871f38da95d25c5965c8460160cb1e3b139e9323L21-L67) [[2]](diffhunk://#diff-f325d021297cc196321fcff0871f38da95d25c5965c8460160cb1e3b139e9323L86-L92)

### Updates to Collection Naming Conventions:
* Replaced old collection names (e.g., `collection_corpus_en_embmodel_v0`) with new static names (e.g., `collection_welearn_en_embmodel`) across multiple files, including `README.md`, `test_qdrant_handler.py`, and `test_qdrant_syncronizer.py`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L104-R107) [[2]](diffhunk://#diff-30e107aa4d7dc1b3e2b008fe41c4aad1aa0cc829aabb5c6dcbe10a5b0e95b54fL61-R69) [[3]](diffhunk://#diff-fec2ea42b598faa329a3f9c99909e6dba69868cc4efb297167a71723d7f99fc7L37-R42)

### Test Cleanup and Adjustments:
* Removed outdated tests related to versioning, such as those for extracting version numbers and retrieving the last collection version, from `test_qdrant_handler.py`.
* Updated test assertions to align with the new collection naming conventions. [[1]](diffhunk://#diff-30e107aa4d7dc1b3e2b008fe41c4aad1aa0cc829aabb5c6dcbe10a5b0e95b54fL144-R105) [[2]](diffhunk://#diff-fec2ea42b598faa329a3f9c99909e6dba69868cc4efb297167a71723d7f99fc7L208-R199)

### Minor Code Adjustments:
* Added `# type: ignore` comments to suppress type-checking warnings in `qdrant_syncronizer.py`. [[1]](diffhunk://#diff-cde4e1498b1ee1dbcc9f9970162492ecfe9ad12c17c6524a3af7a4c36d8f03a1L97-R97) [[2]](diffhunk://#diff-cde4e1498b1ee1dbcc9f9970162492ecfe9ad12c17c6524a3af7a4c36d8f03a1L147-R147) [[3]](diffhunk://#diff-cde4e1498b1ee1dbcc9f9970162492ecfe9ad12c17c6524a3af7a4c36d8f03a1L161-R161)