### PR TITLE
remove useless unique constraint

### DIFF
--- a/alembic/versions/16ff997426d3_remove_error_retrieval_unique_constraint.py
+++ b/alembic/versions/16ff997426d3_remove_error_retrieval_unique_constraint.py
@@ -1,0 +1,38 @@
+"""Remove error retrieval unique constraint
+
+Revision ID: 16ff997426d3
+Revises: a50a1db3ca2a
+Create Date: 2025-06-02 14:23:49.689745
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "16ff997426d3"
+down_revision: Union[str, None] = "a50a1db3ca2a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "error_retrieval_document_id_http_error_code_idxx",
+        "error_retrieval",
+        schema="document_related",
+        type_="unique",
+    )
+
+
+def downgrade() -> None:
+    op.create_unique_constraint(
+        "error_retrieval_document_id_http_error_code_idxx",
+        "error_retrieval",
+        ["document_id", "http_error_code"],
+        schema="document_related",
+    )

--- a/welearn_datastack/data/db_models.py
+++ b/welearn_datastack/data/db_models.py
@@ -166,14 +166,7 @@ class WeLearnDocumentKeyword(Base):
 
 class ErrorRetrieval(Base):
     __tablename__ = "error_retrieval"
-    __table_args__ = (
-        UniqueConstraint(
-            "document_id",
-            "http_error_code",
-            name="error_retrieval_document_id_http_error_code_idx",
-        ),
-        {"schema": DbSchemaEnum.DOCUMENT_RELATED.value},
-    )
+    __table_args__ = ({"schema": DbSchemaEnum.DOCUMENT_RELATED.value},)
 
     id: Mapped[UUID] = mapped_column(
         types.Uuid, primary_key=True, nullable=False, server_default="gen_random_uuid()"


### PR DESCRIPTION
This pull request removes a unique constraint on the `error_retrieval` table in the database schema and updates the corresponding SQLAlchemy model to reflect this change. The change ensures that the table no longer enforces uniqueness for the combination of `document_id` and `http_error_code`.

### Database schema changes:

* [`alembic/versions/16ff997426d3_remove_error_retrieval_unique_constraint.py`](diffhunk://#diff-df54fd8f042f56411892f2441c81722a5d44fcc10e0042fd1765c46b99017cfeR1-R38): Added a migration script to drop the unique constraint `error_retrieval_document_id_http_error_code_idxx` from the `error_retrieval` table in the `document_related` schema. The script includes an `upgrade` function to remove the constraint and a `downgrade` function to restore it.

### SQLAlchemy model updates:

* [`welearn_datastack/data/db_models.py`](diffhunk://#diff-a071d07f66de8be8af126d831c13158e172549456b43e0bb32ccc2675d337e15L169-R169): Updated the `ErrorRetrieval` model to remove the `UniqueConstraint` definition for `document_id` and `http_error_code`, aligning the model with the updated database schema.