### PR TITLE
mv in db

### DIFF
--- a/sql/qty_document_in_qdrant
+++ b/sql/qty_document_in_qdrant
@@ -1,0 +1,11 @@
+-- document_related.qty_document_in_qdrant source
+
+CREATE MATERIALIZED VIEW document_related.qty_document_in_qdrant
+TABLESPACE pg_default
+AS SELECT count(1) AS document_in_qdrant
+   FROM ( SELECT ps.document_id,
+            max(ps.operation_order) AS max_order
+           FROM document_related.process_state ps
+          WHERE ps.title = 'document_in_qdrant'::document_related.step
+          GROUP BY ps.document_id) latest
+WITH NO DATA;


### PR DESCRIPTION
This pull request introduces a new materialized view in the `sql/qty_document_in_qdrant` file to count documents in Qdrant based on their process state.

Database changes:

* [`sql/qty_document_in_qdrant`](diffhunk://#diff-58f6821363e31a303520302ca631207a21c3f9155852b6bb2b99af37e3c97e6cR1-R11): Added a materialized view `document_related.qty_document_in_qdrant` to calculate the number of documents in Qdrant by aggregating data from the `process_state` table.