### PR TITLE
Fix/openalex cant collect url

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -227,7 +227,7 @@ version = "1.1.0"
 description = "Python bindings for the Brotli compression library"
 optional = false
 python-versions = "*"
-groups = ["metrics"]
+groups = ["main", "metrics"]
 files = [
     {file = "Brotli-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e1140c64812cb9b06c922e77f1c26a75ec5e3f0fb2bf92cc8c58720dec276752"},
     {file = "Brotli-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8fd5270e906eef71d4a8d19b7c6a43760c6abcfcc10c9101d14eb2357418de9"},
@@ -4316,4 +4316,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "514d0c5bde8be88412d28c917f9564e045c949cc5cc26d76eb57eda411f9481a"
+content-hash = "602d96b2703fec8117bc8533ba1a2e404588c3c1fd9239010a37be688656595e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ xx_sent_ud_sm = {url = "https://github.com/explosion/spacy-models/releases/downl
 
 lingua-language-detector = "^2.1.1"
 psycopg2-binary = "^2.9.10"
+brotli = "^1.1.0"
 
 [tool.poetry.group.metrics.dependencies]
 alembic = "^1.16.1"

--- a/welearn_datastack/collectors/open_alex_collector.py
+++ b/welearn_datastack/collectors/open_alex_collector.py
@@ -24,7 +24,6 @@ class OpenAlexURLCollector(URLCollector, ABC):
     def _get_oa_json(http_session, params):
         resp_from_openalex = http_session.get(url=OPEN_ALEX_BASE_URL, params=params)
         logger.info(f"OpenAlex response status code: {resp_from_openalex.status_code}")
-        logger.info(f"Resp: '{resp_from_openalex.text}'")
         resp_from_openalex.raise_for_status()
         json_from_oa = resp_from_openalex.json()
         return json_from_oa

--- a/welearn_datastack/collectors/open_alex_collector.py
+++ b/welearn_datastack/collectors/open_alex_collector.py
@@ -24,6 +24,7 @@ class OpenAlexURLCollector(URLCollector, ABC):
     def _get_oa_json(http_session, params):
         resp_from_openalex = http_session.get(url=OPEN_ALEX_BASE_URL, params=params)
         logger.info(f"OpenAlex response status code: {resp_from_openalex.status_code}")
+        logger.info(f"Resp: '{resp_from_openalex.text}'")
         resp_from_openalex.raise_for_status()
         json_from_oa = resp_from_openalex.json()
         return json_from_oa

--- a/welearn_datastack/collectors/open_alex_collector.py
+++ b/welearn_datastack/collectors/open_alex_collector.py
@@ -23,6 +23,7 @@ class OpenAlexURLCollector(URLCollector, ABC):
     @staticmethod
     def _get_oa_json(http_session, params):
         resp_from_openalex = http_session.get(url=OPEN_ALEX_BASE_URL, params=params)
+        logger.info(f"OpenAlex response status code: {resp_from_openalex.status_code}")
         json_from_oa = resp_from_openalex.json()
         return json_from_oa
 

--- a/welearn_datastack/collectors/open_alex_collector.py
+++ b/welearn_datastack/collectors/open_alex_collector.py
@@ -24,6 +24,7 @@ class OpenAlexURLCollector(URLCollector, ABC):
     def _get_oa_json(http_session, params):
         resp_from_openalex = http_session.get(url=OPEN_ALEX_BASE_URL, params=params)
         logger.info(f"OpenAlex response status code: {resp_from_openalex.status_code}")
+        resp_from_openalex.raise_for_status()
         json_from_oa = resp_from_openalex.json()
         return json_from_oa
 

--- a/welearn_datastack/constants.py
+++ b/welearn_datastack/constants.py
@@ -156,7 +156,7 @@ AUTHORIZED_LICENSES = [
 HEADERS = {
     "Accept": "text/html,application/json,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
     "Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3",
-    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Encoding": "gzip, deflate",
     "Connection": "keep-alive",
     "TE": "Trailers",
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/136.0",

--- a/welearn_datastack/constants.py
+++ b/welearn_datastack/constants.py
@@ -156,7 +156,7 @@ AUTHORIZED_LICENSES = [
 HEADERS = {
     "Accept": "text/html,application/json,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
     "Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3",
-    "Accept-Encoding": "gzip, deflate",
+    "Accept-Encoding": "gzip, deflate, br",
     "Connection": "keep-alive",
     "TE": "Trailers",
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/136.0",


### PR DESCRIPTION
This pull request introduces a new dependency for compression and improves error handling and logging in the OpenAlex data collector. These changes enhance functionality and robustness.

### Dependency Update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R46): Added the `brotli` dependency (version `^1.1.0`) for better compression support.

### Error Handling and Logging Improvement:

* [`welearn_datastack/collectors/open_alex_collector.py`](diffhunk://#diff-afd5b5ce21da38e11e7055f605a4c6668ce70ab793eb16d9a4d26b4843a8d52dR26-R27): Enhanced the `_get_oa_json` method by adding a log statement for the OpenAlex response status code and ensuring the response raises an exception for HTTP errors using `raise_for_status`.