### PR TITLE
argoWF

### DIFF
--- a/k8s/welearn-datastack/templates/urlcollectors/cron-workflow.yaml
+++ b/k8s/welearn-datastack/templates/urlcollectors/cron-workflow.yaml
@@ -359,5 +359,15 @@ spec:
                     value: oapen
                   - name: corpus_fix
                     value: "true"
+
+            - name: pressbooks
+              templateRef:
+                name: {{ .name }}
+                template: collect-pressbooks
+              arguments:
+                parameters:
+                  - name: pb_app_id
+                    value: K0SNCQLM4A
+
 {{- end }}
 {{- end }}

--- a/k8s/welearn-datastack/templates/urlcollectors/workflow-template.yaml
+++ b/k8s/welearn-datastack/templates/urlcollectors/workflow-template.yaml
@@ -386,4 +386,45 @@ spec:
           volumeAttributes:
             secretName: {{ $.Values.common.azureShare.secret.name }}
             shareName: {{ $.Values.common.azureShare.name }}
+
+    - name: collect-pressbooks
+      synchronization:
+        semaphores:
+        - configMapKeyRef:
+            name: {{ .collectorSemaphore.configmapName }}
+            key: {{ .collectorSemaphore.standard.keyName }}
+      inputs:
+        parameters:
+        - name: pb_app_id
+      container:
+      {{- with $.Values.image }}
+        image: {{ include "common.pods.image" (dict "root" $ "image" (dict "repository" .repository "path" .path "tag" .tag))}}
+      {{- end }}
+        args:
+          - python
+          - "-m"
+          - welearn_datastack.nodes_workflow.URLCollectors.node_press_books_collect
+        envFrom:
+          - configMapRef:
+              name: {{ .name }}
+        env:
+          - name: PRESSBOOKS_ALGOLIA_APPLICATION_ID
+            value: {{ print "{{inputs.parameters.pb_app_id}}" | quote }}
+        volumeMounts:
+        - name: secrets
+          mountPath: "/secrets"
+          readOnly: true
+        - name: azure-share
+          mountPath: {{ $.Values.common.azureShare.mountPath }}
+      volumes:
+      - name: secrets
+        secret:
+          secretName: {{ .name }}
+      - name: azure-share
+        csi:
+          driver: file.csi.azure.com
+          readOnly: true
+          volumeAttributes:
+            secretName: {{ $.Values.common.azureShare.secret.name }}
+            shareName: {{ $.Values.common.azureShare.name }}
 {{- end }}


### PR DESCRIPTION
This pull request introduces a new workflow step for collecting data from Pressbooks in the `urlcollectors` workflows. The changes include adding a new `pressbooks` step in the `cron-workflow.yaml` file and defining the corresponding `collect-pressbooks` template in the `workflow-template.yaml` file.

### Additions to the `urlcollectors` workflows:

* **New Pressbooks step in `cron-workflow.yaml`:**
  - Added a new step named `pressbooks` under the `spec` section, which references the `collect-pressbooks` template and includes an argument for the `pb_app_id` parameter. (`[k8s/welearn-datastack/templates/urlcollectors/cron-workflow.yamlR362-R371](diffhunk://#diff-d1d02405646a6b92835c108eaecf74b73ec632084b87c8a063d585517d2da73bR362-R371)`)

* **Definition of `collect-pressbooks` template in `workflow-template.yaml`:**
  - Added a new template named `collect-pressbooks` with synchronization settings, input parameters, and container configuration.
  - The container runs a Python module (`welearn_datastack.nodes_workflow.URLCollectors.node_press_books_collect`) and uses environment variables, volume mounts, and Azure file share integration for its operation. (`[k8s/welearn-datastack/templates/urlcollectors/workflow-template.yamlR389-R429](diffhunk://#diff-8f555b73600a29f609d3cf02f30db402d526e2ead1c54c22c0dd9bb5137672faR389-R429)`)