### PR TITLE
Features/uncclearn

### DIFF
--- a/k8s/welearn-datastack/templates/urlcollectors/cron-workflow.yaml
+++ b/k8s/welearn-datastack/templates/urlcollectors/cron-workflow.yaml
@@ -369,5 +369,10 @@ spec:
                   - name: pb_app_id
                     value: K0SNCQLM4A
 
+            - name: unccelearn
+              templateRef:
+                name: {{ .name }}
+                template: collect-unccelearn
+
 {{- end }}
 {{- end }}

--- a/k8s/welearn-datastack/templates/urlcollectors/workflow-template.yaml
+++ b/k8s/welearn-datastack/templates/urlcollectors/workflow-template.yaml
@@ -427,4 +427,40 @@ spec:
           volumeAttributes:
             secretName: {{ $.Values.common.azureShare.secret.name }}
             shareName: {{ $.Values.common.azureShare.name }}
+
+
+    - name: collect-unccelearn
+      synchronization:
+        semaphores:
+        - configMapKeyRef:
+            name: {{ .collectorSemaphore.configmapName }}
+            key: {{ .collectorSemaphore.standard.keyName }}
+      container:
+      {{- with $.Values.image }}
+        image: {{ include "common.pods.image" (dict "root" $ "image" (dict "repository" .repository "path" .path "tag" .tag))}}
+      {{- end }}
+        args:
+          - python
+          - "-m"
+          - welearn_datastack.nodes_workflow.URLCollectors.node_uncclearn_collect
+        envFrom:
+          - configMapRef:
+              name: {{ .name }}
+        volumeMounts:
+        - name: secrets
+          mountPath: "/secrets"
+          readOnly: true
+        - name: azure-share
+          mountPath: {{ $.Values.common.azureShare.mountPath }}
+      volumes:
+      - name: secrets
+        secret:
+          secretName: {{ .name }}
+      - name: azure-share
+        csi:
+          driver: file.csi.azure.com
+          readOnly: true
+          volumeAttributes:
+            secretName: {{ $.Values.common.azureShare.secret.name }}
+            shareName: {{ $.Values.common.azureShare.name }}
 {{- end }}

--- a/tests/document_collector_hub/plugins_test/test_unccelearn.py
+++ b/tests/document_collector_hub/plugins_test/test_unccelearn.py
@@ -1,0 +1,241 @@
+import datetime
+import time
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+import requests
+from bs4 import BeautifulSoup
+
+from welearn_datastack.plugins.scrapers.unccelearn import (
+    UNCCeLearnCollector,
+    format_news_keywords,
+)
+
+
+class MockResponse:
+    def __init__(self, content=None, json_data=None, status_code=200):
+        self.content = content
+        self._json = json_data
+        self.status_code = status_code
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("No JSON data")
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"HTTP {self.status_code}")
+
+
+class TestUNCCeLearnCollector(TestCase):
+    def setUp(self):
+        self.collector = UNCCeLearnCollector()
+        self.mock_base_path = Path(__file__).parent.parent / "resources"
+
+        self.sample_html = """
+            <html>
+              <head></head>
+              <body>
+                <div class="details">
+                  <p class="theme">Climate Change</p>
+                  <p class="time">3-4 hours</p>
+                  <p class="certification">With certification</p>
+                  <p class="type">Self-paced</p>
+                </div>
+                <a id="overview_syllabus_download" href="https://example.org/syllabus.pdf">Download syllabus</a>
+              </body>
+            </html>
+        """.encode(
+            "utf-8"
+        )
+
+        # Métadonnées renvoyées par Tika pour la page HTML (PUT /meta)
+        self.tika_html_meta = {
+            "dc:title": "UN CC:Learn – Climate Course",
+            "dc:description": "A comprehensive overview of climate change.",
+            "og:image": "https://cdn.example.org/og-image.png",
+            "keywords": "climate, environment, SDG 13",
+        }
+
+        self.pdf_text_pages = [
+            ["Hello", "world"],
+            ["foo", "bar"],
+        ]
+        self.pdf_meta = {"pdf:docinfo:created": "2021-01-02T03:04:05Z"}
+
+    def _expected_timestamp_from_str(self, iso_str: str) -> int:
+        fmt = "%Y-%m-%dT%H:%M:%SZ"
+        ts = time.mktime(datetime.datetime.strptime(iso_str, fmt).timetuple())
+        return int(ts)
+
+    def test_format_news_keywords(self):
+        self.assertEqual(format_news_keywords(None), [])
+        self.assertEqual(format_news_keywords("climate"), ["climate"])
+        self.assertEqual(
+            format_news_keywords("climate, environment, SDG 13"),
+            ["climate", "environment", "SDG 13"],
+        )
+
+    def test__convert_duration_to_seconds(self):
+        # 3 hours -> 10800
+        self.assertEqual(
+            self.collector._convert_duration_to_seconds("3 hours"), 3 * 3600
+        )
+        # 3,5 hours (comma) -> 12600
+        self.assertEqual(
+            self.collector._convert_duration_to_seconds("3,5 hours"), int(3.5 * 3600)
+        )
+        # 3.5 hours (point) -> 12600
+        self.assertEqual(
+            self.collector._convert_duration_to_seconds("3.5 hours"), int(3.5 * 3600)
+        )
+        self.assertEqual(
+            self.collector._convert_duration_to_seconds("3-4 hours"), int(3.5 * 3600)
+        )
+
+    def test__get_details_from_html(self):
+        with open(self.mock_base_path / "unccelearn_course.html", "rb") as f:
+            html_content = f.read()
+        soup = BeautifulSoup(html_content, features="html.parser")
+        details = self.collector._get_details(soup)
+        self.assertEqual(details["theme"], "climate change")
+        self.assertEqual(details["duration"], int(4 * 3600))
+        self.assertTrue(details["certifying"])
+        self.assertEqual(details["course-type"], "self-paced courses")
+
+    @patch("welearn_datastack.plugins.scrapers.unccelearn.UNCCeLearnCollector._get_pdf")
+    @patch(
+        "welearn_datastack.plugins.scrapers.unccelearn.extract_txt_from_pdf_with_tika"
+    )
+    def test_get_content_and_file_metadata(self, mock_extract_txt, mock_get_pdf):
+        mock_get_pdf.return_value = b"%PDF-1.4 fake pdf content"
+
+        mock_extract_txt.return_value = (self.pdf_text_pages, self.pdf_meta)
+
+        soup = BeautifulSoup(self.sample_html, features="html.parser")
+        content, file_metadata = self.collector._get_content_and_file_metadata(soup)
+
+        expected_content = "Hello world foo bar"
+        expected_timestamp = self._expected_timestamp_from_str(
+            self.pdf_meta["pdf:docinfo:created"]
+        )
+
+        self.assertEqual(content, expected_content)
+        self.assertEqual(file_metadata["produced_date"], expected_timestamp)
+
+        mock_get_pdf.assert_called_once_with("https://example.org/syllabus.pdf")
+        mock_extract_txt.assert_called_once_with(
+            b"%PDF-1.4 fake pdf content",
+            tika_base_url=self.collector.tika_address,
+            with_metadata=True,
+        )
+
+    @patch(
+        "welearn_datastack.plugins.scrapers.unccelearn.UNCCeLearnCollector._get_content_and_file_metadata"
+    )
+    @patch(
+        "welearn_datastack.plugins.scrapers.unccelearn.UNCCeLearnCollector._get_metadata_from_tika"
+    )
+    @patch("welearn_datastack.plugins.scrapers.unccelearn.get_new_https_session")
+    def test__scrape_url_happy_path(
+        self, mock_get_session, mock_get_meta, mock_get_content_md
+    ):
+        collector = UNCCeLearnCollector()
+
+        sample_html = b"""
+            <html><body>
+                <div class="details">
+                  <p class="thematic-areas">Climate Change</p>
+                  <p class="time">3-4 hours</p>
+                  <p class="certification">With certification</p>
+                  <p class="type">Self-paced</p>
+                </div>
+            </body></html>
+        """
+
+        session = Mock()
+        session.get.return_value = MockResponse(content=sample_html)
+        mock_get_session.return_value = session
+
+        mock_get_meta.return_value = {
+            "dc:title": "UN CC:Learn – Climate Course",
+            "dc:description": "A comprehensive overview",
+            "og:image": "https://cdn.example.org/og.png",
+            "keywords": "climate, environment",
+        }
+
+        mock_get_content_md.return_value = (
+            "Lorem ipsum CLEAN CONTENT dolor sit amet consectetur",
+            {"produced_date": 1234567890},
+        )
+
+        url = "https://example.org/course"
+        doc = collector._scrape_url(url)
+
+        self.assertEqual(doc.document_url, url)
+        self.assertEqual(doc.document_title, "UN CC:Learn – Climate Course")
+        self.assertEqual(doc.document_desc, "A comprehensive overview")
+        self.assertEqual(
+            doc.document_content, "Lorem ipsum CLEAN CONTENT dolor sit amet consectetur"
+        )
+
+        details = doc.document_details
+        self.assertEqual(details["image"], "https://cdn.example.org/og.png")
+        self.assertEqual(details["keywords"], ["climate", "environment"])
+        self.assertEqual(details["type"], "MOOC")
+        self.assertEqual(details["theme"], "climate change")  # get_details
+        self.assertEqual(details["course-type"], "self-paced")
+        self.assertTrue(details["certifying"])
+        self.assertEqual(details["duration"], int(3.5 * 3600))  # "3-4 hours" => 3.5h
+        self.assertEqual(details["produced_date"], 1234567890)
+
+        session.get.assert_called_once()
+        mock_get_meta.assert_called_once()
+        mock_get_content_md.assert_called_once()
+
+    @patch(
+        "welearn_datastack.plugins.scrapers.unccelearn.UNCCeLearnCollector._scrape_url"
+    )
+    def test_run_mixed_success_and_error(self, mock_scrape):
+        # Arrange: first URL raises, second URL returns a doc
+        ok_doc = Mock()
+        fail_url = "https://fail.example"
+        ok_url = "https://ok.example"
+        mock_scrape.side_effect = [Exception("boom"), ok_doc]
+
+        collector = UNCCeLearnCollector()
+
+        # Act
+        collected, errors = collector.run([fail_url, ok_url])
+
+        # Assert: one collected doc, one error containing the failing URL
+        self.assertEqual(len(collected), 1, "Should collect exactly one document")
+        self.assertIs(
+            collected[0],
+            ok_doc,
+            "Collected document should be the one returned by _scrape_url",
+        )
+        self.assertEqual(len(errors), 1, "Should register exactly one error")
+        self.assertIn(fail_url, errors[0], "Error list should include the failing URL")
+
+    @patch(
+        "welearn_datastack.plugins.scrapers.unccelearn.UNCCeLearnCollector._scrape_url"
+    )
+    def test_run_all_success(self, mock_scrape):
+        # Arrange: both URLs succeed
+        doc1, doc2 = Mock(), Mock()
+        urls = ["https://a.example", "https://b.example"]
+        mock_scrape.side_effect = [doc1, doc2]
+
+        collector = UNCCeLearnCollector()
+
+        # Act
+        collected, errors = collector.run(urls)
+
+        # Assert: both docs collected, no errors
+        self.assertEqual(
+            collected, [doc1, doc2], "Should collect all returned documents in order"
+        )
+        self.assertEqual(errors, [], "Should not report any errors when all succeed")

--- a/tests/document_collector_hub/resources/unccelearn_course.html
+++ b/tests/document_collector_hub/resources/unccelearn_course.html
@@ -1,0 +1,797 @@
+<!DOCTYPE html>
+
+<html  dir="ltr" lang="en" xml:lang="en">
+<head>
+
+    <title>Course: Intégration du changement climatique dans les politiques nationale, sectorielle et locale | One UN Climate Change Learning Partnership</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="keywords" content="moodle, Course: Intégration du changement climatique dans les politiques nationale, sectorielle et locale | One UN Climate Change Learning Partnership" />
+<link rel="stylesheet" type="text/css" href="https://unccelearn.org/theme/yui_combo.php?rollup/3.18.1/yui-moodlesimple-min.css" /><script id="firstthemesheet" type="text/css">/** Required in order to fix style inclusion problems in IE with YUI **/</script><link rel="stylesheet" type="text/css" href="https://unccelearn.org/theme/styles.php/uncc/1753775342_1753775431/all" />
+<script>
+//<![CDATA[
+var M = {}; M.yui = {};
+M.pageloadstarttime = new Date();
+M.cfg = {"wwwroot":"https:\/\/unccelearn.org","apibase":"https:\/\/unccelearn.org\/r.php\/api","homeurl":{},"sesskey":"yeDJcVv1MA","sessiontimeout":"28800","sessiontimeoutwarning":"1200","themerev":"1753775342","slasharguments":1,"theme":"uncc","iconsystemmodule":"core\/icon_system_fontawesome","jsrev":"1753775342","admin":"admin","svgicons":true,"usertimezone":"Europe\/Zurich","language":"en","courseId":121,"courseContextId":379643,"contextid":379643,"contextInstanceId":121,"langrev":1753775342,"templaterev":"1753775342","siteId":1,"userId":1};var yui1ConfigFn = function(me) {if(/-skin|reset|fonts|grids|base/.test(me.name)){me.type='css';me.path=me.path.replace(/\.js/,'.css');me.path=me.path.replace(/\/yui2-skin/,'/assets/skins/sam/yui2-skin')}};
+var yui2ConfigFn = function(me) {var parts=me.name.replace(/^moodle-/,'').split('-'),component=parts.shift(),module=parts[0],min='-min';if(/-(skin|core)$/.test(me.name)){parts.pop();me.type='css';min=''}
+if(module){var filename=parts.join('-');me.path=component+'/'+module+'/'+filename+min+'.'+me.type}else{me.path=component+'/'+component+'.'+me.type}};
+YUI_config = {"debug":false,"base":"https:\/\/unccelearn.org\/lib\/yuilib\/3.18.1\/","comboBase":"https:\/\/unccelearn.org\/theme\/yui_combo.php?","combine":true,"filter":null,"insertBefore":"firstthemesheet","groups":{"yui2":{"base":"https:\/\/unccelearn.org\/lib\/yuilib\/2in3\/2.9.0\/build\/","comboBase":"https:\/\/unccelearn.org\/theme\/yui_combo.php?","combine":true,"ext":false,"root":"2in3\/2.9.0\/build\/","patterns":{"yui2-":{"group":"yui2","configFn":yui1ConfigFn}}},"moodle":{"name":"moodle","base":"https:\/\/unccelearn.org\/theme\/yui_combo.php?m\/1753775342\/","combine":true,"comboBase":"https:\/\/unccelearn.org\/theme\/yui_combo.php?","ext":false,"root":"m\/1753775342\/","patterns":{"moodle-":{"group":"moodle","configFn":yui2ConfigFn}},"filter":null,"modules":{"moodle-core-actionmenu":{"requires":["base","event","node-event-simulate"]},"moodle-core-blocks":{"requires":["base","node","io","dom","dd","dd-scroll","moodle-core-dragdrop","moodle-core-notification"]},"moodle-core-chooserdialogue":{"requires":["base","panel","moodle-core-notification"]},"moodle-core-dragdrop":{"requires":["base","node","io","dom","dd","event-key","event-focus","moodle-core-notification"]},"moodle-core-event":{"requires":["event-custom"]},"moodle-core-handlebars":{"condition":{"trigger":"handlebars","when":"after"}},"moodle-core-lockscroll":{"requires":["plugin","base-build"]},"moodle-core-maintenancemodetimer":{"requires":["base","node"]},"moodle-core-notification":{"requires":["moodle-core-notification-dialogue","moodle-core-notification-alert","moodle-core-notification-confirm","moodle-core-notification-exception","moodle-core-notification-ajaxexception"]},"moodle-core-notification-dialogue":{"requires":["base","node","panel","escape","event-key","dd-plugin","moodle-core-widget-focusafterclose","moodle-core-lockscroll"]},"moodle-core-notification-alert":{"requires":["moodle-core-notification-dialogue"]},"moodle-core-notification-confirm":{"requires":["moodle-core-notification-dialogue"]},"moodle-core-notification-exception":{"requires":["moodle-core-notification-dialogue"]},"moodle-core-notification-ajaxexception":{"requires":["moodle-core-notification-dialogue"]},"moodle-core_availability-form":{"requires":["base","node","event","event-delegate","panel","moodle-core-notification-dialogue","json"]},"moodle-course-categoryexpander":{"requires":["node","event-key"]},"moodle-course-dragdrop":{"requires":["base","node","io","dom","dd","dd-scroll","moodle-core-dragdrop","moodle-core-notification","moodle-course-coursebase","moodle-course-util"]},"moodle-course-management":{"requires":["base","node","io-base","moodle-core-notification-exception","json-parse","dd-constrain","dd-proxy","dd-drop","dd-delegate","node-event-delegate"]},"moodle-course-util":{"requires":["node"],"use":["moodle-course-util-base"],"submodules":{"moodle-course-util-base":{},"moodle-course-util-section":{"requires":["node","moodle-course-util-base"]},"moodle-course-util-cm":{"requires":["node","moodle-course-util-base"]}}},"moodle-form-dateselector":{"requires":["base","node","overlay","calendar"]},"moodle-form-shortforms":{"requires":["node","base","selector-css3","moodle-core-event"]},"moodle-question-chooser":{"requires":["moodle-core-chooserdialogue"]},"moodle-question-searchform":{"requires":["base","node"]},"moodle-availability_completion-form":{"requires":["base","node","event","moodle-core_availability-form"]},"moodle-availability_date-form":{"requires":["base","node","event","io","moodle-core_availability-form"]},"moodle-availability_grade-form":{"requires":["base","node","event","moodle-core_availability-form"]},"moodle-availability_group-form":{"requires":["base","node","event","moodle-core_availability-form"]},"moodle-availability_grouping-form":{"requires":["base","node","event","moodle-core_availability-form"]},"moodle-availability_profile-form":{"requires":["base","node","event","moodle-core_availability-form"]},"moodle-mod_assign-history":{"requires":["node","transition"]},"moodle-mod_customcert-rearrange":{"requires":["dd-delegate","dd-drag"]},"moodle-mod_quiz-autosave":{"requires":["base","node","event","event-valuechange","node-event-delegate","io-form","datatype-date-format"]},"moodle-mod_quiz-dragdrop":{"requires":["base","node","io","dom","dd","dd-scroll","moodle-core-dragdrop","moodle-core-notification","moodle-mod_quiz-quizbase","moodle-mod_quiz-util-base","moodle-mod_quiz-util-page","moodle-mod_quiz-util-slot","moodle-course-util"]},"moodle-mod_quiz-modform":{"requires":["base","node","event"]},"moodle-mod_quiz-questionchooser":{"requires":["moodle-core-chooserdialogue","moodle-mod_quiz-util","querystring-parse"]},"moodle-mod_quiz-quizbase":{"requires":["base","node"]},"moodle-mod_quiz-toolboxes":{"requires":["base","node","event","event-key","io","moodle-mod_quiz-quizbase","moodle-mod_quiz-util-slot","moodle-core-notification-ajaxexception"]},"moodle-mod_quiz-util":{"requires":["node","moodle-core-actionmenu"],"use":["moodle-mod_quiz-util-base"],"submodules":{"moodle-mod_quiz-util-base":{},"moodle-mod_quiz-util-slot":{"requires":["node","moodle-mod_quiz-util-base"]},"moodle-mod_quiz-util-page":{"requires":["node","moodle-mod_quiz-util-base"]}}},"moodle-message_airnotifier-toolboxes":{"requires":["base","node","io"]},"moodle-editor_atto-editor":{"requires":["node","transition","io","overlay","escape","event","event-simulate","event-custom","node-event-html5","node-event-simulate","yui-throttle","moodle-core-notification-dialogue","moodle-editor_atto-rangy","handlebars","timers","querystring-stringify"]},"moodle-editor_atto-plugin":{"requires":["node","base","escape","event","event-outside","handlebars","event-custom","timers","moodle-editor_atto-menu"]},"moodle-editor_atto-menu":{"requires":["moodle-core-notification-dialogue","node","event","event-custom"]},"moodle-editor_atto-rangy":{"requires":[]},"moodle-report_eventlist-eventfilter":{"requires":["base","event","node","node-event-delegate","datatable","autocomplete","autocomplete-filters"]},"moodle-report_loglive-fetchlogs":{"requires":["base","event","node","io","node-event-delegate"]},"moodle-gradereport_history-userselector":{"requires":["escape","event-delegate","event-key","handlebars","io-base","json-parse","moodle-core-notification-dialogue"]},"moodle-qbank_editquestion-chooser":{"requires":["moodle-core-chooserdialogue"]},"moodle-tool_lp-dragdrop-reorder":{"requires":["moodle-core-dragdrop"]},"moodle-assignfeedback_editpdf-editor":{"requires":["base","event","node","io","graphics","json","event-move","event-resize","transition","querystring-stringify-simple","moodle-core-notification-dialog","moodle-core-notification-alert","moodle-core-notification-warning","moodle-core-notification-exception","moodle-core-notification-ajaxexception"]},"moodle-atto_accessibilitychecker-button":{"requires":["color-base","moodle-editor_atto-plugin"]},"moodle-atto_accessibilityhelper-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_align-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_bold-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_charmap-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_clear-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_collapse-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_emojipicker-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_emoticon-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_equation-button":{"requires":["moodle-editor_atto-plugin","moodle-core-event","io","event-valuechange","tabview","array-extras"]},"moodle-atto_h5p-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_html-beautify":{},"moodle-atto_html-button":{"requires":["promise","moodle-editor_atto-plugin","moodle-atto_html-beautify","moodle-atto_html-codemirror","event-valuechange"]},"moodle-atto_html-codemirror":{"requires":["moodle-atto_html-codemirror-skin"]},"moodle-atto_image-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_indent-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_italic-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_link-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_managefiles-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_managefiles-usedfiles":{"requires":["node","escape"]},"moodle-atto_media-button":{"requires":["moodle-editor_atto-plugin","moodle-form-shortforms"]},"moodle-atto_noautolink-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_orderedlist-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_recordrtc-button":{"requires":["moodle-editor_atto-plugin","moodle-atto_recordrtc-recording"]},"moodle-atto_recordrtc-recording":{"requires":["moodle-atto_recordrtc-button"]},"moodle-atto_rtl-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_strike-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_subscript-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_superscript-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_table-button":{"requires":["moodle-editor_atto-plugin","moodle-editor_atto-menu","event","event-valuechange"]},"moodle-atto_title-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_underline-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_undo-button":{"requires":["moodle-editor_atto-plugin"]},"moodle-atto_unorderedlist-button":{"requires":["moodle-editor_atto-plugin"]}}},"gallery":{"name":"gallery","base":"https:\/\/unccelearn.org\/lib\/yuilib\/gallery\/","combine":true,"comboBase":"https:\/\/unccelearn.org\/theme\/yui_combo.php?","ext":false,"root":"gallery\/1753775342\/","patterns":{"gallery-":{"group":"gallery"}}}},"modules":{"core_filepicker":{"name":"core_filepicker","fullpath":"https:\/\/unccelearn.org\/lib\/javascript.php\/1753775342\/repository\/filepicker.js","requires":["base","node","node-event-simulate","json","async-queue","io-base","io-upload-iframe","io-form","yui2-treeview","panel","cookie","datatable","datatable-sort","resize-plugin","dd-plugin","escape","moodle-core_filepicker","moodle-core-notification-dialogue"]},"core_comment":{"name":"core_comment","fullpath":"https:\/\/unccelearn.org\/lib\/javascript.php\/1753775342\/comment\/comment.js","requires":["base","io-base","node","json","yui2-animation","overlay","escape"]}},"logInclude":[],"logExclude":[],"logLevel":null};
+M.yui.loader = {modules: {}};
+
+//]]>
+</script>
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-49457143-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-49457143-1');
+  gtag('config', 'AW-985455004');
+</script>
+<style>
+#page-course-view-unccelearn .overview .content-top .welcome img.img-fluid {
+    max-width: 100%;
+    height: auto;
+}
+#page-course-view-unccelearn .overview .content-top .welcome img.atto_image_button_left {
+    float: left;
+    margin: 0 .5em 0 0;
+    max-width: calc(100% - 1em);
+}
+#page-course-view-unccelearn .overview .content-top .welcome img.atto_image_button_right {
+    float: right;
+    margin: 0 0 0 .5em;
+    max-width: calc(100% - 1em);
+}
+</style><link rel="canonical" href="https://unccelearn.org/course/view.php?id=121&amp;page=overview&amp;lang=fr"><meta property="og:title" content="Intégration du changement climatique dans les politiques nationale, sectorielle et locale"><meta name="twitter:title" content="Intégration du changement climatique dans les politiques nationale, sectorielle et locale"><meta property="og:type" content="website"><meta name="twitter:card" content="summary_large_image"><meta name="description" content="Ce module développé par le Centre Régional AGRHYMET (CRA) dans le cadre du programme de formation du Master Changement Climatique et Développement Durable (CCDD) offre aux étudiants l’opportunité de revisiter les concepts clés du Changement climatique et de maitriser l’ensemble des étapes essentiels du processus de l’intégration du CC dans les politiques de développement et la planification budgétaire afin de favoriser la mise en œuvre des actions prioritaires d’adaptation et d’atténuation. "><meta property="og:description" content="Ce module développé par le Centre Régional AGRHYMET (CRA) dans le cadre du programme de formation du Master Changement Climatique et Développement Durable (CCDD) offre aux étudiants l’opportunité de revisiter les concepts clés du Changement climatique et de maitriser l’ensemble des étapes essentiels du processus de l’intégration du CC dans les politiques de développement et la planification budgétaire afin de favoriser la mise en œuvre des actions prioritaires d’adaptation et d’atténuation. "><meta name="twitter:description" content="Ce module développé par le Centre Régional AGRHYMET (CRA) dans le cadre du programme de formation du Master Changement Climatique et Développement Durable (CCDD) offre aux étudiants l’opportunité de revisiter les concepts clés du Changement climatique et de maitriser l’ensemble des étapes essentiels du processus de l’intégration du CC dans les politiques de développement et la planification budgétaire afin de favoriser la mise en œuvre des actions prioritaires d’adaptation et d’atténuation. "><meta property="og:url" content="https://unccelearn.org/course/view.php?id=121&amp;page=overview&amp;lang=fr"><meta name="twitter:url" content="https://unccelearn.org/course/view.php?id=121&amp;page=overview&amp;lang=fr"><meta property="og:image" content="https://unccelearn.org/pluginfile.php/379643/format_unccelearn/background/0/BIG%20COURSE%20COVER.jpg"><meta name="twitter:image:src" content="https://unccelearn.org/pluginfile.php/379643/format_unccelearn/background/0/BIG%20COURSE%20COVER.jpg">
+    <link rel="shortcut icon" href="https://unccelearn.org/theme/uncc/pix/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="https://unccelearn.org/theme/uncc/pix/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://unccelearn.org/theme/uncc/pix/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://unccelearn.org/theme/uncc/pix/favicon-16x16.png">
+    <link rel="mask-icon" href="https://unccelearn.org/theme/uncc/pix/safari-pinned-tab.svg" color="#4396d6">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        .pagelayout-admin #page-header,
+        .pagelayout-forcedadmin #page-header,
+        .pagelayout-mypublic #page-header,
+        .pagelayout-standard #page-header,
+        .pagelayout-report #page-header,
+        .pagelayout-base #page-header {
+          margin-left: calc(((100vw - 100%) / 2) * -1);
+        }
+    </style>
+
+</head>
+<body  id="page-course-view-unccelearn" class="format-unccelearn limitedwidth  path-course path-course-view gecko dir-ltr lang-en yui-skin-sam yui3-skin-sam unccelearn-org pagelayout-course course-121 context-379643 category-4 theme ">
+
+    <div>
+    <a class="sr-only sr-only-focusable" href="#maincontent">Skip to main content</a>
+</div><script src="https://unccelearn.org/lib/javascript.php/1753775342/lib/polyfills/polyfill.js"></script>
+<script src="https://unccelearn.org/theme/yui_combo.php?rollup/3.18.1/yui-moodlesimple-min.js"></script><script src="https://unccelearn.org/lib/javascript.php/1753775342/lib/javascript-static.js"></script>
+<script>
+//<![CDATA[
+document.body.className += ' jsenabled';
+//]]>
+</script>
+
+
+
+
+
+        <div id="platform-header" class="platform-header">
+            <div class="wrapper">
+                <div class="platform-header-top">
+                    <div class="wrapper">
+                        <p class="logo">
+                            <a href="https://unccelearn.org" class="navbar-brand" title="Back to home">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 94">
+                                    <path style="fill: #4397D7;" d="M55.3572,0C33.7453,0,16.1708,17.5745,16.1708,39.1865s17.5745,39.1865,39.1865,39.1865
+                                        s39.1865-17.5745,39.1865-39.1865S76.9692,0,55.3572,0z M55.3572,46.6675c-4.1324,0-7.4811-3.3487-7.4811-7.4811
+                                        s3.3487-7.4811,7.4811-7.4811s7.4811,3.3487,7.4811,7.4811S59.4896,46.6675,55.3572,46.6675z M60.9858,32.8929
+                                        c-1.3775-1.235-3.1587-2.0187-5.1299-2.1374v-6.4123c3.7287,0.1187,7.1248,1.615,9.666,4.0136L60.9858,32.8929z M54.8822,30.7554
+                                        c-1.9712,0.1187-3.7524,0.9025-5.1299,2.1374l-4.5361-4.5361c2.5412-2.3987,5.9373-3.8949,9.666-4.0136L54.8822,30.7554
+                                        L54.8822,30.7554z M49.0874,33.5816c-1.235,1.3775-2.0187,3.1587-2.1374,5.1299h-6.4123c0.1187-3.7286,1.615-7.1248,4.0136-9.666
+                                        L49.0874,33.5816z M46.9499,39.6614c0.1187,1.9712,0.9025,3.7524,2.1374,5.1299l-4.5361,4.5361
+                                        c-2.3987-2.5412-3.8949-5.9373-4.0136-9.666L46.9499,39.6614L46.9499,39.6614z M49.7524,45.48
+                                        c1.3775,1.235,3.1587,2.0187,5.1299,2.1374v6.4123c-3.7286-0.1187-7.1248-1.615-9.666-4.0136L49.7524,45.48z M55.8322,47.5937
+                                        c1.9712-0.1187,3.7524-0.9025,5.1299-2.1374l4.5361,4.5361c-2.5412,2.3987-5.9373,3.8949-9.666,4.0136V47.5937z M61.6508,44.7913
+                                        c1.235-1.3775,2.0187-3.1587,2.1374-5.1299h6.4123c-0.1188,3.7286-1.615,7.1248-4.0136,9.666L61.6508,44.7913z M63.7883,38.7115
+                                        c-0.1187-1.9712-0.9025-3.7524-2.1374-5.1299l4.5361-4.5361c2.3987,2.5412,3.8949,5.9373,4.0136,9.666H63.7883z M66.1869,27.6918
+                                        c-2.7312-2.5649-6.3411-4.1799-10.3547-4.2986v-7.1248c5.9611,0.1187,11.3759,2.5412,15.3896,6.3886L66.1869,27.6918z
+                                         M54.8822,23.3931c-3.9899,0.1187-7.6235,1.7337-10.3547,4.2986l-5.0349-5.0349c4.0136-3.8474,9.4285-6.2698,15.3896-6.3886
+                                        L54.8822,23.3931L54.8822,23.3931z M43.8625,28.3567c-2.5649,2.7312-4.1799,6.3411-4.2986,10.3547h-7.1248
+                                        c0.1187-5.9611,2.5412-11.3759,6.3886-15.3896L43.8625,28.3567z M39.5876,39.6614c0.1187,3.9899,1.7337,7.6235,4.2986,10.3547
+                                        l-5.0586,5.0349c-3.8474-4.0136-6.2698-9.4285-6.3886-15.3896H39.5876z M44.5513,50.6812
+                                        c2.7312,2.5649,6.3411,4.1799,10.3547,4.2986v7.1248c-5.9611-0.1187-11.3759-2.5412-15.3896-6.3886L44.5513,50.6812z
+                                         M55.8322,54.956c3.9899-0.1187,7.6235-1.7337,10.3547-4.2986l5.0349,5.0349c-4.0136,3.8474-9.4285,6.2698-15.3896,6.3886V54.956z
+                                         M66.8519,49.9924c2.5649-2.7312,4.1799-6.3411,4.2986-10.3547h7.1248c-0.1187,5.9611-2.5412,11.3759-6.3886,15.3896
+                                        L66.8519,49.9924z M71.1506,38.7115c-0.1187-3.9899-1.7337-7.6235-4.2986-10.3547l5.0349-5.0349
+                                        c3.8474,4.0136,6.2698,9.4285,6.3886,15.3896H71.1506z M71.8868,21.9919c-4.1799-4.0136-9.8322-6.5311-16.0546-6.6498V9.0248
+                                        c7.956,0.1187,15.1758,3.3487,20.4957,8.5023L71.8868,21.9919z M54.8822,15.3183c-6.2223,0.1187-11.8747,2.6362-16.0546,6.6498
+                                        l-4.4411-4.4411c5.3199-5.1536,12.5397-8.3835,20.4957-8.5023V15.3183z M38.1627,22.6569
+                                        c-4.0136,4.1799-6.5311,9.8322-6.6498,16.0546h-6.2936c0.1187-7.956,3.3487-15.1758,8.5023-20.4957L38.1627,22.6569z
+                                         M31.5129,39.6614c0.1187,6.2223,2.6362,11.8747,6.6498,16.0546l-4.4411,4.4411c-5.1536-5.3199-8.3835-12.5397-8.5023-20.4957
+                                        L31.5129,39.6614L31.5129,39.6614z M38.8277,56.381c4.1799,4.0136,9.8322,6.5311,16.0546,6.6498v6.2936
+                                        c-7.956-0.1187-15.1758-3.3487-20.4957-8.5023L38.8277,56.381z M55.8322,63.0546c6.2223-0.1187,11.8747-2.6362,16.0546-6.6498
+                                        l4.4411,4.4411c-5.3199,5.1536-12.5397,8.3835-20.4957,8.5023V63.0546z M72.5755,55.716
+                                        c4.0136-4.1799,6.5311-9.8322,6.6498-16.0546h6.2936c-0.1188,7.956-3.3487,15.1758-8.5023,20.4957L72.5755,55.716z
+                                         M79.2253,38.7115c-0.1187-6.2223-2.6362-11.8747-6.6498-16.0546l4.4411-4.4411c5.1536,5.3199,8.3835,12.5397,8.5023,20.4957
+                                        H79.2253z M77.0166,16.8621c-5.5099-5.3436-12.9434-8.6685-21.1844-8.7873V0.95c10.1885,0.1187,19.427,4.2511,26.2193,10.8772
+                                        L77.0166,16.8621z M54.8822,8.0748c-8.2173,0.1187-15.6746,3.4437-21.1844,8.7873l-5.0111-5.0349
+                                        C35.479,5.2011,44.7175,1.0687,54.906,0.95v7.1248H54.8822z M33.0328,17.527c-5.3436,5.5099-8.6685,12.9434-8.7873,21.1844
+                                        h-7.1248c0.1187-10.1885,4.2511-19.427,10.8772-26.2193L33.0328,17.527z M24.2693,39.6614
+                                        c0.1187,8.2173,3.4437,15.6746,8.7873,21.1844L27.998,65.857c-6.6261-6.7686-10.7347-16.0071-10.8535-26.1956H24.2693z
+                                         M33.7215,61.5109c5.5099,5.3436,12.9434,8.6685,21.1844,8.7873v7.1248c-10.1885-0.1187-19.427-4.2511-26.2193-10.8772
+                                        L33.7215,61.5109z M55.8322,70.2981c8.2173-0.1187,15.6746-3.4437,21.1844-8.7873l5.0349,5.0349
+                                        c-6.7923,6.6261-16.0308,10.7585-26.2193,10.8772L55.8322,70.2981L55.8322,70.2981z M77.6816,60.8221
+                                        c5.3436-5.5099,8.6685-12.9434,8.7873-21.1844h7.1248c-0.1187,10.1885-4.2511,19.427-10.8772,26.2193L77.6816,60.8221z
+                                         M86.4689,38.7115c-0.1188-8.2173-3.4437-15.6746-8.7873-21.1844l5.0349-5.0349c6.6261,6.7923,10.7585,16.0308,10.8772,26.2193
+                                        H86.4689z"/>
+                                    <path style="fill: #4397D7;" d="M6.2326,43.4138C4.2109,32.5517-1.3867,27.3091,7.0408,16.4347c-2.2063,3.7124-0.3152,10.3375-0.4046,15.3182
+                                        c0.1025-0.0713-0.6836,5.8949-0.2133,5.415c0.3383-5.1634,4.126-8.6514,7.9557-12.0648c0.76-0.7125,1.3062-1.5437,1.6625-2.4462
+                                        c-0.2613,2.1137-0.855,4.2986-1.805,6.2223C11.79,33.8191,7.0876,37.809,6.2326,43.4138z M19.1523,12.5634
+                                        c2.2087-2.9212,4.1324-6.1986,7.0298-8.716c-9.0888,3.361-10.7349,5.4956-13.5846,14.7009
+                                        C14.7824,16.5058,17.2998,14.9859,19.1523,12.5634z M7.9426,64.052c3.0637,2.4224,6.7211,4.2986,9.5235,6.4361
+                                        c-4.282-7.3906-1.8358-17.0922-5.3674-24.5806c0.4733,7.9682-3.728,11.2552,1.1642,19.5694
+                                        c-1.0216-0.9262-1.7579-2.0899-2.4466-3.2299C7.5246,57.025,0.5062,53.1094,0.1222,47.0156
+                                        C-0.6682,53.8985,2.426,60.0456,7.9426,64.052z M7.8476,29.9242c3.2455-6.4639,12.9649-9.2576,12.9668-17.4798
+                                        c-1.3771,3.7526-5.4858,5.3201-8.2169,7.885c-1.4487,1.3537-2.5649,2.9924-3.2062,4.7024
+                                        c-0.0238-1.4234,0.985-2.9581,1.3298-4.4174c1.1877-3.9899,0.9739-8.7635,4.8688-11.4472
+                                        c-2.0342,0.5305-3.7631,1.869-5.2711,3.5727C6.1337,17.4188,8.4701,24.202,7.8476,29.9242z M8.9401,57.426l0.285,0.2375
+                                        c-0.3087-2.1374-0.475-4.4649,0.1425-6.5073c1.6902-5.7357,3.8383-11.9786,3.3963-18.002
+                                        c-1.7639,6.6088-8.1151,11.4841-5.2721,19.2371c-0.0479,0.0711-0.1191,0.1424-0.1904,0.0949
+                                        c-0.8075-1.8762-0.9975-3.9899-1.52-5.9848C4.3802,41.2052,0.319,36.764,1.5065,30.6367
+                                        c-2.1123,4.8359-1.7305,10.6255-0.1899,15.4608C2.5752,50.3962,6.7789,53.4836,8.9401,57.426z M40.0517,82.1728
+                                        c6.479-0.6491-2.4386-0.3308-6.1272-4.2989c-3.5388-3.2296-6.6737-6.6733-10.4498-9.1907
+                                        c2.9687,3.9899,3.7999,9.7847,9.2148,11.8034c3.5017,0.8143,3.6064,1.4556-0.0239,0.5701
+                                        c-6.9822-1.4963-15.4845,0.4274-20.7093-5.51C18.0588,86.5831,29.8664,85.5054,40.0517,82.1728z M28.367,79.2516
+                                        c-6.8246-5.9867-5.0572-14.501-12.7297-22.2294c3.1894,7.6854,0.6913,13.2497,8.004,19.4505
+                                        c-1.1404-0.5222-2.1617-1.3297-3.2066-2.1847c-5.3551-4.3104-13.995-5.6565-16.8582-12.3301
+                                        c0.9487,5.4009,5.2696,10.1642,9.9375,13.1761C17.912,77.9394,23.5236,77.6528,28.367,79.2516z M99.9985,20.6144
+                                        c0.3448,1.4593,1.3535,2.9941,1.3298,4.4174c-0.6412-1.71-1.7574-3.3487-3.2062-4.7024c-2.7312-2.5649-6.8398-4.1324-8.2169-7.885
+                                        c0.0019,8.2222,9.7213,11.0159,12.9668,17.4798c-0.6225-5.7222,1.7139-12.5054-2.4712-17.1843
+                                        c-1.508-1.7037-3.2369-3.0421-5.2711-3.5727C99.0246,11.8509,98.8108,16.6246,99.9985,20.6144z M104.9382,46.5013
+                                        c-0.5225,1.995-0.7125,4.1087-1.52,5.9848c-0.0712,0.0475-0.1425-0.0237-0.1904-0.0949c2.843-7.753-3.5081-12.6283-5.2721-19.2371
+                                        c-0.4421,6.0235,1.7061,12.2663,3.3963,18.002c0.6175,2.0424,0.4512,4.3699,0.1425,6.5073l0.285-0.2375
+                                        c2.1612-3.9424,6.3648-7.0298,7.6234-11.3285c1.5406-4.8353,1.9225-10.6249-0.1899-15.4608
+                                        C110.4005,36.764,106.3394,41.2052,104.9382,46.5013z M104.0833,31.7529c-0.1025-0.0713,0.6836,5.8949,0.2133,5.415
+                                        c-0.3383-5.1634-4.126-8.6514-7.9557-12.0648c-0.76-0.7125-1.3062-1.5437-1.6625-2.4462c0.2613,2.1137,0.855,4.2986,1.805,6.2223
+                                        c2.4462,4.9399,7.1486,8.9298,8.0035,14.5346c2.0218-10.8621,7.6193-16.1047-0.8082-26.9791
+                                        C105.8851,20.1471,103.9939,26.7722,104.0833,31.7529z M93.2535,70.4881c2.8024-2.1374,6.4598-4.0136,9.5235-6.4361
+                                        c5.5166-4.0064,8.6108-10.1536,7.8204-17.0364c-0.384,6.0937-7.4024,10.0094-10.6941,15.2314
+                                        c-0.6887,1.14-1.425,2.3037-2.4466,3.2299c4.8921-8.3142,0.6909-11.6013,1.1642-19.5694
+                                        C95.0893,53.396,97.5355,63.0976,93.2535,70.4881z M78.054,81.0567c-3.6303,0.8855-3.5256,0.2441-0.0239-0.5701
+                                        c5.4148-2.0187,6.2461-7.8135,9.2148-11.8034c-3.7762,2.5174-6.9111,5.9611-10.4498,9.1907
+                                        c-3.6887,3.9681-12.6063,3.6499-6.1272,4.2989c10.1853,3.3326,21.9929,4.4103,28.0955-6.6261
+                                        C93.5385,81.4841,85.0362,79.5604,78.054,81.0567z M61.1206,81.6028c-1.9553,0-3.8843,0.3261-5.7608,0.8918
+                                        c-1.8765-0.5657-3.8055-0.8918-5.7608-0.8918c-9.8929,0.0149-18.8614,10.0743-28.4755,3.3481
+                                        c1.8525,2.328,4.3461,3.7767,6.9348,4.7504c11.9505,3.9435,16.1722-6.2491,23.3692-6.6976c0.6254,0,1.2543,0.075,1.8852,0.2088
+                                        c-4.9099,1.957-9.3726,5.4127-12.8778,8.745c0.6412,0.7362,1.4725,1.4012,2.2562,2.0424
+                                        c3.8901-4.0179,8.2858-8.3559,12.6687-10.1471c4.383,1.7913,8.7786,6.1292,12.6687,10.1471
+                                        c0.7837-0.6412,1.615-1.3062,2.2562-2.0425c-3.5052-3.3323-7.968-6.788-12.8778-8.745c0.6308-0.1338,1.2598-0.2088,1.8852-0.2088
+                                        c7.197,0.4485,11.4188,10.6411,23.3692,6.6976c2.5887-0.9737,5.0824-2.4224,6.9348-4.7504
+                                        C79.9819,91.6771,71.0135,81.6177,61.1206,81.6028z M91.5673,12.5634c1.8524,2.4224,4.3699,3.9424,6.5548,5.9848
+                                        C95.2724,9.343,93.6263,7.2084,84.5375,3.8474C87.4349,6.3648,89.3586,9.6423,91.5673,12.5634z M90.2848,74.288
+                                        c-1.045,0.855-2.0662,1.6625-3.2066,2.1847c7.3127-6.2007,4.8146-11.765,8.004-19.4505
+                                        c-7.6724,7.7284-5.9051,16.2427-12.7297,22.2294c4.8434-1.5988,10.455-1.3122,14.853-4.1177
+                                        c4.668-3.0118,8.9888-7.7752,9.9375-13.1761C104.2798,68.6315,95.6399,69.9776,90.2848,74.288z"/>
+                                    <path style="fill: #4397D7;" d="M19.5932,48.7549c0.2505,0.1857,0.267-0.0687,0.3207-0.1883c0.2474-0.5515,0.8562-0.8785,1.4778-0.7976
+                                        c1.3109-0.1354,0.967,0.6283,1.7874,0.1292c0.751-0.4946,1.055,0.7352,1.8567,0.5996c1.1152,0.1251,3.5081,0.3686,4.0379-0.9038
+                                        c0.0952-1.1589-0.1976-2.3052,0.6195-3.2927c0.3851-0.5472,0.9504-0.9641,1.1644-1.6454c0.5559-0.391,1.6183-0.5696,2.1426,0.1087
+                                        c0.4551,0.5345,1.1584,0.6977,1.6481,0.1223c-0.3077-0.6187-0.8332-1.0921-0.1313-1.6942
+                                        c0.2212-0.3807,0.0678-0.8581,0.4786-1.166c0.1724-0.1913,0.2028-0.3723,0.2164-0.6352c0.014-0.2702,0.3303-0.5112,0.4492-0.7925
+                                        c0.9752-1.3659,0.7802-3.8749,2.545-4.5598c0.4607-0.1023,3.0021-0.6568,1.4355-1.0874c0.4123-0.7945,1.3261-1.0143,2.8852-0.6787
+                                        c0.1973-0.4619,0.5419-0.7519,1.0461-0.9047c1.0339-0.2559,1.6712,0.6833,2.4343,1.1708
+                                        c1.0619,0.5917,2.4751,0.1265,3.6625,0.2657c1.4042,0.0275,1.6411-1.9462,2.8649-2.1834
+                                        c-0.1481,0.7638,0.5676,0.4208,1.0751,0.5197c0.2301,0.0264,0.3164,0.1859,0.235,0.452
+                                        c-0.2552,0.4912-0.1032,1.5102,0.4747,0.6629c0.4667,0.4467,0.6934,0.4228,1.018-0.2191c-0.5354-0.3-1.9707-0.5449-0.825-1.0023
+                                        c1.4094-0.7172,1.5934,0.4465,2.9553,0.1376c0.4631-0.717,2.166-2.245,1.5925-0.2284c-1.0839,1.4058,0.1282,0.3795,0.721,1.4279
+                                        c0.0979,0.137,0.4249,0.1599,0.6429,0.1493c1.8409-0.0242-0.2283-1.1748,0.88-1.9206c0.5814-0.6216,1.0817,0.2949,1.8296,0.1481
+                                        c1.8149-0.4289,1.1561,0.9408,1.9555,0.4808c0.3379-0.9955,1.2297-1.126,2.0215-0.7091
+                                        c-0.2958,0.4084-0.8828,0.7625-1.0065,1.2556c0.1958,0.3037,0.1686,1.0533,0.5801,1.0494c0.05-0.8605,0.3105-0.8918,1.1155-0.4436
+                                        c-0.0608-0.7814-0.3966-1.9025,0.8306-1.5413c3.5765,0.539,1.9045,1.3619,3.5034,2.0569c0.7449-0.0343,0.296,0.5858,0.2747,1.0394
+                                        c0.3998,0.0737,0.614-0.1256,0.766-0.4388c0.6517-1.2658,2.89-0.2786,1.9424,1.0296c-0.8312,1.4862,0.461,1.802,1.1689,0.5829
+                                        c0.1751-0.4598,0.3104-1.0257,0.8743-1.1109c0.5937,0.4995,0.5356,1.4234-0.2898,1.8405
+                                        c-0.1435,0.0961-0.3433,0.2072-0.3796,0.3471c-0.2833,0.8896-1.2837,0.4945-1.9466,0.7414
+                                        c-0.3336,0.0834-0.3298,0.3931-0.2487,0.612c0.1537,0.4152,0.0185,0.5638-0.3798,0.6356
+                                        c-0.5114,0.262-0.7245,0.9431-1.1422,1.3269c-0.641,0.6237,1.0279,1.5725,0.9972,2.4294
+                                        c0.0932,0.6919,0.5245,1.0115,1.0854,1.1786c0.6421,0.1281,1.7762,1.4742,0.7043,1.6245
+                                        c-1.1596,0.0259-2.0141,1.0832-3.1717,0.4359c-0.2155,0.7498-0.2141,0.7356-1.02,0.6524
+                                        c-1.1548-0.1578-1.185,1.5208-1.9144,2.0518c-0.6203,0.5741-1.0052,1.4784-1.9946,1.6155
+                                        c-0.0701,0.0097-0.1123,0.2215-0.1674,0.3393c0.375,0.3094,1.1585-0.3275,1.6675-0.3946c0.0794-0.5764,0.2773-1.1848,0.9656-1.124
+                                        c1.7066,0.424,0.0101,4.1062-0.3025,5.1537c-0.3735,1.4105-2.0372-0.1602-2.97-0.0072c-0.4598,0.1224-3.0942-1.4243-2.4717-0.4225
+                                        c1.6483,0.5032,3.227,1.8423,4.9999,1.3118c1.0648-0.2105,1.6559-3.6002,2.2667-0.9897
+                                        c-0.0365,0.8847,0.6741,2.5213,0.0572,3.1475c-1.8661,1.2161-0.3237,2.5747,1.0137,3.3201
+                                        c1.7506,1.1396-2.0662,2.5082-0.9355,3.0782c1.2501,0.5471-0.4064,1.4953-0.0496,2.3801c0.4993,0.3877,0.1376,0.535-0.1646,0.7888
+                                        c-1.3729,1.2698-2.6672,2.6391-4.4101,3.3939c-0.4542,0.1669-0.8952,0.3519-1.3984,0.3664
+                                        c-0.5537,0.2587-0.6134,0.2325-0.877-0.4041c-1.4233,0.071-1.989-1.5561-3.2489-2.0339
+                                        c-0.5774-0.3517-0.9676-1.3775-0.7039-2.0242c0.361-0.761-0.1785-0.9761-0.5104-1.5009c0.067-0.8624-1.3139-0.2985-1.4753-1.2892
+                                        c-0.2177-1.0205-1.1826-0.9497-2.0208-1.2177c-0.9925-0.0901-1.9159,0.3871-2.9157,0.2062
+                                        c-0.662-0.0848-1.3784-0.3413-2.0439-0.3574c-0.252-0.5989-1.1716-0.5-1.2837-1.2968c-0.0615-0.4371-0.345-0.8528-0.5748-1.2514
+                                        c-1.8827-1.227,0.0278-0.705,0.1554-2.412c0.2117-0.5521,0.9706-0.7023,1.2581-1.1695c0.6216-0.7184,1.5664-1.0289,2.4411-1.2692
+                                        c0.3138-0.0535,0.7239,0.012,0.9266-0.1644c0.612-0.5327,1.3529-0.573,2.0757-0.7142c0.5476-0.0673,1.1707-0.4159,1.2025,0.3734
+                                        c0.2314,0.8516,1.4904,0.5384,2.1548,0.8429c0.2371-1.7393,4.5837-1.1426,3.2112-2.8565
+                                        c-0.6832-0.855-0.9883,0.5961-1.7466,0.2715c-0.4161-0.3233-0.4768-1.021-0.0004-1.4083
+                                        c0.6382-0.5891,1.6698-0.3877,2.0875-1.1663c-0.5032-0.3903-1.1234-0.2861-1.7569-0.4174
+                                        c-0.0104,0.1452-0.0254,0.3563-0.0435,0.6089c-1.8063-0.185-0.1577,0.6374-1.1915,1.7688
+                                        c-0.9021,0.2988,0.552,0.9015,0.8808,1.3465c-0.3284,0.7139-1.3218-0.1008-1.7928-0.3349
+                                        c-0.6269-0.464-0.6975-1.418-1.7585-0.9982c0.5053,0.3263,1.3272,0.3507,0.9799,1.1168
+                                        c-0.1147,0.2444-0.1412,0.6001-0.3829,0.7501c-0.2474,0.0395-0.2951-0.25-0.206-0.4157c0.0691-0.1164,0.1987-0.1968,0.3014-0.2918
+                                        c-1.1947-1.3184-2.9409-0.4719-3.756,0.781c-0.5549,0.519-1.4363,0.3422-1.9753-0.1404c0.2734-0.4533-0.0143-2.0723,0.8089-1.7066
+                                        c0.5576,0.2745,1.4118-0.1874,0.7932-0.7893c-0.6982-0.8775,1.0281-0.3259,1.181-1.0458
+                                        c1.1482-3.1129,1.5985,0.0498,2.5462-1.8127c0.1087-0.4436,0.635-0.7137-0.1569-0.8859c0.1699-0.61,0.0653-1.7177-0.5752-0.7835
+                                        c-0.0023,0.4195-0.2045,0.8664,0.1229,1.2806c0.0923,0.525,0.1554,0.9255-0.5717,0.4887c-0.58-0.14-1.5935-0.6389-1.1576-1.332
+                                        c0.6551-0.833,0.4373-2.6103,1.8622-2.5125c0.5205-0.0362,1.3301,0.1593,1.5124-0.4992c0.1039-0.5474,0.573-1.2535,0.3477-1.7722
+                                        c-0.7115-0.1577-0.3941-0.7791-0.5417-1.1835c-0.1289-0.7275-0.1982-1.3517-1.1284-1.1714
+                                        c-1.3986-0.1298,1.5895-1.2249,0.7335-1.9776c-0.2273-0.3751-0.1131-0.7169-0.1398-1.2593
+                                        c-0.2598,0.1711-0.4789,0.2428-0.5764,0.3933c-0.2914,0.7484-1.5301-0.0936-0.4792-0.2581
+                                        c0.2993-0.0766,0.3992-0.2726,0.1873-0.4799c-0.6943-1.0655-1.7739-0.9696-2.6954-1.7032
+                                        c-0.1974-0.2064-0.6032-0.6296-1.0666-0.2705c0.9447,1.8631-3.7606,1.2312-2.3477,3.1082c0.4604,0.7481-0.9524,0.8862-0.6319,1.67
+                                        c0.0439,0.1098-0.228,0.4079-0.4126,0.5354c-0.5372,0.3709-0.5488,0.3542-0.2616,0.9733
+                                        c0.3316-0.3759,0.5711-0.8826,0.9822-1.1683c0.9061-0.1485-0.2181-1.5894,1.0323-1.1229
+                                        c0.5206,0.2899,0.5188,0.9181,0.0003,1.1774c-0.638,0.3315-0.0007,1.2563-0.9128,1.4689
+                                        c-0.9015,0.1551-1.0945,2.2129-1.791,1.9447c-1.2761-0.6303-0.4941-1.6947,0.6351-1.7684
+                                        c-0.6861-0.8066-1.0135-0.0063-1.6561-0.1859c-0.3509-0.6138,0.3943-1.4023-0.8382-1.3142
+                                        c0.0281,0.5895-0.4264,0.5016-0.7797,0.5041c-0.3507,0.0025-0.5333,0.1013-0.5091,0.4821
+                                        c0.0328,0.5076-0.5897,0.4476-0.688,0.9465c0.6417,0.3284,1.1557-0.2454,1.25-0.8585c0.3774-0.0588,0.7421-0.0948,0.9558,0.3312
+                                        c1.1447,0.4466,0.6291,1.3368,0.4613,2.2594c-0.1088,0.6302-0.7974,0.826-1.0099,1.3737
+                                        c0.2589,0.9253-0.5822,0.8514-0.6812,1.6634c-0.0777,0.3975-0.2713,0.5975-0.7474,0.5794
+                                        c0.2472-0.9629-0.4254-1.2289-1.0908-1.5413c-0.8964-0.2271-0.4481-1.4538-1.0652-1.1845
+                                        c-0.3241,0.1434-0.5069,0.0289-0.6066-0.2819c-0.3201-0.948-1.6459-0.1325-2.2455-0.7662
+                                        c-1.1078-1.0284-1.6088,0.5016-2.1692,1.2727c0.4738-1.0554-1.4913-1.2479,0.3934-1.2201
+                                        c-0.6123-0.8635-0.9046-0.7011-0.0121-1.5062c0.4697-0.9218-0.0841-2.0538,0.3601-3.0482
+                                        c0.3486-1.0251-1.0253-0.8551-1.6595-0.9779c-0.4353-0.0208-0.9229,0.744-0.7634,1.2049
+                                        c0.0877,0.2532,0.1147,0.6125,0.5386,0.5855c0.0388-0.0025,0.1222,0.0811,0.118,0.1168c0.0934,0.9424-0.5284,1.232-1.3724,0.9444
+                                        c-0.1515,0.2668-0.4914,0.4884-0.1369,0.8671c-0.0001,0.6363-0.8683,0.6427-1.4273,1.027
+                                        c0.1106,1.5973,0.1983,2.141,1.2968,3.3883c0.3145,0.5785,0.4764,1.1665,0.4031,1.8009c-0.078,0.6748-0.076,0.716,0.5749,0.7609
+                                        c0.283,0.5526,0.2987,1.3461,0.933,0.6016c0.2349,0.2804,0.0998,0.3777-0.1443,0.481c-2.0914,0.6623,0.0164,2.885,0.3213,4.2013
+                                        c0.2116,0.8273-0.9391,1.2038,0.1796,1.7167c0.8766,0.7602,1.6971,1.5941,2.5385,2.3955
+                                        c0.2892,0.5914-0.2331,1.2956,0.2064,1.9114c0.241,0.6902,0.2453,1.231-0.6177,1.2304c-2.6342-0.1118-1.813,1.0015-4.6886,0.7804
+                                        c-0.4153,0.0368-0.5811-0.1517-0.6103-0.4936c-0.003-0.7662-1.0283-0.5541-1.3893-1.0701
+                                        c-0.5001-0.5637-1.0309-0.3642-1.5541-0.138c-1.0006,0.3685-1.4662-0.8722-2.427-0.9802
+                                        c-0.7387-0.2237-1.1022-1.2245-1.7185-1.567c-2.1038,0.4073-1.3771-2.053-2.6271-2.0515
+                                        c-0.4728,0.1166-0.2572-0.5115-0.5956-0.6065c-0.6503,0.06-0.8463-0.6083-1.293-0.8956c-0.1164-0.0567-0.3311-0.0536-0.4293,0.02
+                                        c-0.9579,0.7106-1.0174-1.1876-1.9956-0.8423C21.4722,57.034,19.0964,50.1361,19.5932,48.7549z M65.804,47.7036
+                                        c-0.4375-0.658-1.1606-0.8077-1.9109-1.0612C63.6569,47.7589,65.0067,47.8276,65.804,47.7036z M22.5676,48.3395
+                                        c-0.3175-0.2972-0.818-0.2504-0.818,0.1986C21.9058,49.0636,22.2056,48.5568,22.5676,48.3395z M76.9137,23.8172
+                                        c0.8603-0.047,1.0831,0.7544,1.8512,0.9783c1.4119,0.3939,1.8972,2.3815,3.1804,2.8785c0.6439-0.3461,1.3995-0.5525,1.7198-1.2741
+                                        c0.1268-0.1781,0.2239-0.4472,0.395-0.5098c0.3796-0.1388,0.4895-0.3652,0.2957-0.6699
+                                        c-0.9725-1.4765-1.7902-3.0878-3.2217-4.1625c-0.4322-0.556-0.7583-1.1944-1.159-1.845
+                                        c-0.9362-0.2043-2.1398-1.6357-1.7808-2.7606c0.0032-0.1598-0.2338-0.4331-0.3426-0.4523
+                                        c-0.6694,0.006-0.0883-0.9844-0.8269-0.9025c-1.0088-0.0247-0.1553-1.5993-1.2542-1.7842
+                                        c-1.2976-1.9525-1.1447-0.5385-1.7828-1.4187c0.0099-0.6716-0.7254-0.5214-1.1654-0.6874
+                                        c-1.0611-0.5593-2.1902,0.0094-3.3131,0.1494c-0.7718,0.1401-1.2306,0.715-1.1701,1.3046
+                                        c0.7387,0.6504,1.7016,0.9021,1.6679,1.9707c0.0568,0.4206,0.0718,0.849,0.518,1.0942c0.0729,0.04,0.1108,0.2167,0.0999,0.3236
+                                        c-0.0533,0.5226-0.186,1.0426,0.2384,1.501c0.1033,0.1115,0.1072,0.3266,0.1316,0.4976c0.0993,0.6964,0.3154,0.7983,0.9243,0.4251
+                                        c0.8567-0.569,2.2455,0.2638,1.9555,1.3082c-0.7929,1.292,0.8711,1.861,1.2526,3.0055
+                                        C76.516,21.1422,75.7972,23.6183,76.9137,23.8172z M50.6239,44.7172c0.4669-0.4208,0.9742-0.4771,1.5334-0.5551
+                                        c0.7754-0.4401,0.4372,0.2206,1.2372-0.2581c0.4133-0.3705,0.7817-0.4761,0.7553-1.1126
+                                        c0.0085-0.1144-0.0086-0.3005,0.0496-0.3305c0.4809-0.248,0.5133-0.703,0.6021-1.1529c0.3033-1.5791-1.3146-0.623-1.3638-1.5946
+                                        c0.0303-0.3842-0.0131-0.8544-0.5095-0.8453c-0.3011-0.0092-0.5752,0.011-0.5725,0.4152
+                                        c-0.0789,0.6902-0.6136,1.2328-0.6641,1.9278c-0.2657,0.2592-0.29,0.7921-0.8376,0.7381
+                                        c-0.5033,0.587-0.8595,1.3937-0.8874,2.2003C49.9704,44.5766,50.3673,44.9485,50.6239,44.7172z M69.1563,19.4109
+                                        c0.0004,0.0536,0.088,0.1126,0.1435,0.159c0.5201,0.4354,0.5326,0.585,0.2566,1.2013c-0.0829,0.1852-0.0791,0.6055-0.0075,0.6321
+                                        c0.907,0.6238,1.3062,1.6673,2.3058,2.241c0.2833,0.3564,0.7857-0.0515,0.9792-0.2674c0.8245-1.1277-1.7326-1.8766-0.5978-2.785
+                                        c0.2262-0.3302-1.3099-1.8089-1.6593-1.8406c-0.9079,0.0283-1.1406-1.0426-1.6735-1.5801
+                                        c-0.2724-0.3251-0.7546-0.8552-1.1817-0.4998c-0.2303,0.6502,1.3896,0.5781,0.6838,1.8805
+                                        C68.8245,18.6869,69.1529,18.9081,69.1563,19.4109z M77.0959,31.9513c0.2851,0.5536,1.2955,0.307,1.0216-0.2957
+                                        c-0.4966-0.2641-0.1665-0.8214-0.3623-1.241c-0.2678-0.5123-0.1778-1.7035-0.8212-1.8144
+                                        c-0.4524-0.1773-1.3682-0.7174-0.5706-1.1378c0.2968-0.2347,0.3186-0.4606,0.0549-0.7393
+                                        c-0.3505-0.7979-0.864-0.2396-1.5185-0.0151c-0.8525,0.6084,1.8417,1.4894-0.2231,1.5069
+                                        C73.4701,30.813,75.0674,28.1138,77.0959,31.9513z M76.9404,59.9925c-0.3017-1.046,0.1167-2.5342-0.8683-3.2353
+                                        c-0.3689-0.2505-0.9005-0.0288-1.0132,0.4128c-0.0123,0.7496-0.9772,2.366-0.3286,2.8197
+                                        c0.2229,0.6176,0.0549,0.9604,0.8542,0.903C76.1845,60.7418,77.1919,60.9212,76.9404,59.9925z M79.0095,33.5276
+                                        c0.2773-1.0554-0.127-0.8836-1.0015-0.8891c-0.3907,0.0515-0.7129,0.7199-0.5042,1.0512
+                                        c1.0057,1.4609-0.5142,2.0366,0.0786,3.5704C78.9508,36.7173,78.8249,34.7977,79.0095,33.5276z M66.625,28.71
+                                        c-0.9837,0.344-2.2535-1.218-2.9087-0.0428c-0.0347,0.136,0.1533,0.4728,0.2167,0.4671c0.6449-0.1398,0.8087,0.4854,1.3104,0.6442
+                                        c1.1364-0.2524,3.0411,1.447,2.6601-0.424C67.4801,29.0269,67.2377,28.5968,66.625,28.71z M71.7751,27.4991
+                                        c-0.619,0.3248,0.3336,1.0408-0.312,1.6425c-0.1897,0.2529-0.3871,0.5001-0.5818,0.7507c0.33,0.2199,1.1201,0.256,1.2387,0.008
+                                        c0.1759-0.3678,0.4493-0.2716,0.7214-0.2947c1.8161-0.282-0.1823-0.1901-0.5738-0.6769c0.5596-0.1173,0.181-1.0191,0.8568-0.9861
+                                        c0.0293-0.4116,0.0583-0.8196,0.0908-1.2757C71.7049,26.5972,72.5332,26.7677,71.7751,27.4991z M61.9158,5.5466
+                                        c0.4446-0.2641,1.0272-0.3938,1.3123-0.867c-0.148-0.0877-0.2902-0.2316-0.4456-0.2475
+                                        c-1.2347,0.2831-2.5569,0.0588-3.7989,0.5612C58.595,6.4941,61.122,5.2213,61.9158,5.5466z M58.6421,5.6363
+                                        c-0.3804-1.1751-2.0598-0.0431-2.6632,0.4273c0.4107,0.288,1.1868-0.0493,1.5793,0.5689
+                                        c0.3469,0.1715,0.9146,0.2251,1.1515,0.5106c0.2563,0.3238,0.5107,0.2992,0.9317,0.2716
+                                        C59.3331,6.7301,58.8091,6.3685,58.6421,5.6363z M38.3676,45.1552c-0.1354-0.5423,0.1894-1.0818-0.1579-1.5948
+                                        c-0.1947-0.7698,0.6118-3.6162-0.8456-2.904c0.5639,0.2592,0.8185,2.0385,0.0428,1.9665
+                                        c-1.1394,0.3563,1.4983,1.346,0.1293,1.3438C37.0405,44.6039,38.1448,46.3349,38.3676,45.1552z M72.8714,24.8021
+                                        c0.1184,0.0231,0.3164,0.1328,0.3145,0.1984c-0.0104,0.7113,0.7572,0.633,1.2046,0.934c0.9814-0.7956-0.2536-1.7205-0.8243-2.4767
+                                        C73.2325,23.5282,72.0592,24.675,72.8714,24.8021z M77.9775,29.6917c0.4816,0.9229,0.6626,1.8176,1.0479,2.8104
+                                        c0.4233-0.7303-0.2963-3.8168-0.8559-4.1376C77.9544,28.7854,77.698,29.1698,77.9775,29.6917z M66.906,18.6961
+                                        c0.1779-0.7591,1.646-0.2376,0.9065-1.2165c-0.2428-0.2577-1.0992-0.318-1.418-0.1367c-0.2197,0.4744-0.8671,1.7407,0.1305,1.7637
+                                        C66.6184,19.0109,66.8312,18.8814,66.906,18.6961z M65.3837,16.0115c-0.9017-0.385-1.2315-1.408-2.1754-1.6748
+                                        c-0.1,0.4867,0.4564,1.1704,0.9031,1.5012c0.6005,0.3985,1.2914,0.6893,1.7624,1.2474
+                                        C66.0549,16.5025,65.7452,16.1606,65.3837,16.0115z M56.091,10.7631c-0.2809-0.1215-0.6618-0.902-0.9171-0.4162
+                                        c-0.4511,0.5443-0.1454,1.4878,0.6162,1.5383C56.5076,11.9656,56.8034,11.0894,56.091,10.7631z M54.608,48.0259
+                                        c0.2409,0.4933-0.3366,0.851-0.2382,1.2942c0.3952,0.1953,1.5957-0.1787,1.221-0.74c-0.3241-0.1952-0.2393-0.4382-0.163-0.7756
+                                        C55.267,47.0532,54.3792,47.2429,54.608,48.0259z M72.9505,10.4455c0.4633,0.5074,1.1426,1.1108,1.8219,1.2557
+                                        C74.9865,10.3553,73.9931,9.7986,72.9505,10.4455z M77.5074,27.654c1.3759,0.9775-0.2052-2.7407-1.1927-1.837
+                                        C76.7088,26.47,77.4802,26.8098,77.5074,27.654z M62.9899,11.909c0.1951-0.5971-0.3593-1.0652-0.9423-1.0016
+                                        c-0.3624,0.0322-0.6948,0.0269-0.605-0.5388C60.6196,11.0466,62.4634,11.8938,62.9899,11.909z M63.3994,29.3387
+                                        c-0.3556-0.4931-1.3595-0.2832-1.8896-0.1305C62.036,29.8433,62.9933,30.3319,63.3994,29.3387z M24.6232,57.6863
+                                        c-0.3336-0.4291-0.4799-1.0605-1.2545-1.2492C23.3455,57.2352,24.9654,59.4273,24.6232,57.6863z M75.7984,23.9695
+                                        c-0.8143,0.3089,0.6793,1.4483,1.1821,1.4395C77.2971,24.7323,76.1767,24.4181,75.7984,23.9695z M52.7592,44.6811
+                                        c-0.3592,1.2117,1.2086,1.4224,1.3616,0.3337C53.6432,44.8977,53.1999,44.7891,52.7592,44.6811z M58.1046,40.31
+                                        c-0.6425,0.4484,0.2887,1.2398,0.5363,1.6998C59.3171,41.8916,58.4956,40.4331,58.1046,40.31z M52.2606,12.9034
+                                        c-0.0242-0.6148-0.3894-0.7983-1.453-0.73C50.9678,12.7309,51.5563,13.0265,52.2606,12.9034z M33.4649,69.4113
+                                        c0.3673-0.5302-0.4881-1.194-1.1249-1.0035C32.706,68.6999,32.9427,69.5048,33.4649,69.4113z M54.0119,47.8826
+                                        c-0.3509,0.3638-0.7219,0.6351-0.4173,1.188C54.2124,48.8727,54.6769,48.1393,54.0119,47.8826z M55.8058,41.7259
+                                        c0.0924,1.1409,0.5472,0.6344,0.8085-0.1671C56.4757,41.2598,55.8961,41.5906,55.8058,41.7259z M73.6668,58.0371
+                                        c-0.3271,0.2801-0.7623,0.4325-0.2601,0.8482C73.727,58.9466,74.0987,58.1889,73.6668,58.0371z M76.7465,42.7378
+                                        c-1.2448-0.1426-1.0656,0.4177,0.0183,0.5438C76.971,43.2046,76.7981,42.7685,76.7465,42.7378z M56.1747,29.5228
+                                        c0.0801,0.0536,0.1688,0.1627,0.2388,0.1517c0.6962-0.0794,0.8218,0.4857,1.1969,0.9745
+                                        C57.5715,29.8632,57.0236,29.3557,56.1747,29.5228z M52.7562,30.5182c0.2616-0.3437,1.2786-0.7232,0.5461-1.0328
+                                        C53.1477,29.8359,52.4413,30.2521,52.7562,30.5182z M22.042,55.4051c-0.0116-0.4296-0.248-0.6786-0.611-0.8711
+                                        C21.2835,54.7678,21.7112,55.744,22.042,55.4051z M60.6017,11.0494c-0.7241,0.0431,0.1778,0.6108,0.4455,0.7254
+                                        C61.3809,11.4872,60.7957,11.2669,60.6017,11.0494z M63.9592,4.2005c0.8173-0.4214,0.2402-0.5777-0.391-0.3951
+                                        C63.3543,3.961,63.8623,4.2084,63.9592,4.2005z M48.442,22.6751c-0.5903-0.3695-0.9159-0.3965-0.5118,0.2971
+                                        C48.1036,22.8716,48.2295,22.7984,48.442,22.6751z M59.6426,29.7921c0.2757-0.1657,0.434-0.2608,0.6898-0.4144
+                                        C59.8162,28.8463,59.8302,29.2132,59.6426,29.7921z M61.3977,29.2386c-0.3501,0.0774-0.6793-0.1294-0.9901,0.2007
+                                        C60.9884,29.5789,61.159,29.5501,61.3977,29.2386z"/>
+                                	<path style="fill: #4397D7;" d="M138.9105,16.9577V52.394c0,18.7096,9.3038,25.7353,21.6777,25.7353c13.0661,0,22.767-7.5221,22.767-25.9313
+                                		V16.9577h-7.9189v35.7339c0,13.1653-5.8419,19.1041-14.6518,19.1041c-8.0158,0-14.0538-5.7403-14.0538-19.1041V16.9577H138.9105z
+                                		 M205.1311,77.0423V51.307c0-9.9987-0.0992-17.2255-0.4964-24.8468l0.2977-0.0968c2.9682,6.532,6.9288,13.3616,11.1851,20.0944
+                                		l19.1016,30.5844h7.9216V16.9577h-7.326V42.199c0,9.3038,0.1984,16.6299,0.8909,24.6457l-0.2977,0.0992
+                                		c-2.7695-6.1348-6.3333-12.4705-10.6887-19.4988l-19.3051-30.4873h-8.6114V77.042h7.3284V77.0423z M314.0198,68.8235
+                                		c-3.1698,1.4865-7.9192,2.4742-12.7719,2.4742c-14.5499,0-23.0618-9.4031-23.0618-24.0527
+                                		c0-15.7366,9.4036-24.7451,23.5566-24.7451c5.0484,0,9.2051,1.0893,12.0786,2.4742l1.9791-6.4351
+                                		c-2.0797-0.9901-6.9296-2.5734-14.3541-2.5734c-18.7066,0-31.4785,12.6715-31.4785,31.4779
+                                		c0,19.6973,12.6713,30.3884,29.6978,30.3884c7.3239,0,13.1634-1.3849,15.9363-2.8713L314.0198,68.8235z M364.8954,68.8235
+                                		c-3.1671,1.4865-7.9165,2.4742-12.7665,2.4742c-14.5525,0-23.0671-9.4031-23.0671-24.0527
+                                		c0-15.7366,9.4062-24.7451,23.5593-24.7451c5.051,0,9.2078,1.0893,12.0759,2.4742l1.9818-6.4351
+                                		c-2.077-0.9901-6.9296-2.5734-14.3514-2.5734c-18.7119,0-31.4784,12.6715-31.4784,31.4779
+                                		c0,19.6973,12.6686,30.3884,29.6951,30.3884c7.3239,0,13.166-1.3849,15.9363-2.8713L364.8954,68.8235z"/>
+                                	<path style="fill: #33B057;" d="M380.4402,46.5502c3.2624,0,5.2442-2.375,5.2442-5.544c0-3.2659-2.0771-5.6408-5.2469-5.6408
+                                		c-3.0667,0-5.2469,2.2758-5.2469,5.6408c-0.0979,3.169,2.0797,5.544,5.2469,5.544H380.4402L380.4402,46.5502z M380.4402,78.0326
+                                		c3.2624,0,5.2442-2.3774,5.2442-5.544c0-3.2682-2.0771-5.6408-5.2469-5.6408c-3.0667,0-5.2469,2.2758-5.2469,5.6408
+                                		c-0.0979,3.169,2.0797,5.544,5.2469,5.544H380.4402L380.4402,78.0326z M434.2078,56.9471c0.1958-0.8909,0.2964-2.0797,0.2964-3.663
+                                		c0-7.9166-3.6646-20.2905-17.8203-20.2905c-12.5681,0-20.3894,10.2942-20.3894,23.2611s8.0198,21.777,21.2811,21.777
+                                		c6.9323,0,11.6817-1.4841,14.4546-2.7721l-1.3864-5.6408c-2.8708,1.2856-6.3343,2.2757-11.9781,2.2757
+                                		c-7.9166,0-14.5499-4.3554-14.7483-14.9473H434.2078L434.2078,56.9471z M403.9174,51.3062
+                                		c0.5953-5.4471,4.0588-12.7708,12.0786-12.7708c8.8056,0,10.8853,7.7229,10.7874,12.7708H403.9174z M468.8931,56.9439V51.303
+                                		h-22.1384v5.6408H468.8931z M481.1436,77.0423h33.6534v-6.5344h-25.7342V16.9577h-7.9193V77.0423z M557.6582,56.9471
+                                		c0.1958-0.8909,0.2963-2.0797,0.2963-3.663c0-7.9166-3.6619-20.2905-17.8176-20.2905c-12.5707,0-20.3894,10.2942-20.3894,23.2611
+                                		s8.0172,21.777,21.2784,21.777c6.9323,0,11.6817-1.4841,14.4546-2.7721l-1.3865-5.6408c-2.8708,1.2856-6.3343,2.2757-11.978,2.2757
+                                		c-7.9166,0-14.5499-4.3554-14.7483-14.9473H557.6582L557.6582,56.9471z M527.3678,51.3062
+                                		c0.5953-5.4471,4.0588-12.7708,12.0786-12.7708c8.8083,0,10.888,7.7229,10.7874,12.7708H527.3678z M599.0323,50.6111
+                                		c0-8.6114-3.2677-17.6176-16.529-17.6176c-5.4453,0-10.6922,1.4841-14.3514,3.7598l1.778,5.2463
+                                		c3.0693-2.0773,7.226-3.1666,11.3828-3.1666c8.8135-0.0992,9.8005,6.4325,9.8005,9.9987v0.8885
+                                		c-16.7275-0.0968-26.0331,5.6408-26.0331,16.0366c0,6.2364,4.4557,12.3713,13.2666,12.3713c6.1359,0,10.8853-3.0674,13.264-6.4325
+                                		h0.2937l0.6932,5.4448h7.0276c-0.4921-2.9706-0.5927-6.6336-0.5927-10.3934V50.6111L599.0323,50.6111z M591.4121,62.5903
+                                		c0,0.7917-0.1005,1.6825-0.3969,2.4742c-1.2859,3.6606-4.9479,7.2242-10.6921,7.2242c-3.9583,0-7.3239-2.2758-7.3239-7.5221
+                                		c0-8.413,9.7026-9.8994,18.3124-9.701V62.59L591.4121,62.5903z M612.5953,77.042h7.9166V53.9797c0-1.288,0.1005-2.4766,0.299-3.663
+                                		c1.0875-5.8419,5.0458-9.9987,10.5916-9.9987c1.0875,0,1.8786,0.0992,2.6724,0.1984v-7.4229
+                                		c-0.6959-0.0992-1.3892-0.1984-2.1802-0.1984c-5.2469,0-10.0942,3.663-12.076,9.5026h-0.2963l-0.3942-8.5122h-6.9297
+                                		c0.2964,4.0575,0.3943,8.413,0.3943,13.4608L612.5953,77.042z M643.0815,77.042h7.9166V51.0091c0-1.288,0.1985-2.6729,0.4975-3.663
+                                		c1.3838-4.3554,5.4426-8.0185,10.5889-8.0185c7.4271,0,9.9989,5.8419,9.9989,12.87V77.042H680V51.3067
+                                		c0-14.8481-9.303-18.4116-15.341-18.4116c-7.1254,0-12.1765,4.0575-14.3514,8.0185h-0.1984l-0.4948-7.0281h-6.9296
+                                		c0.2963,3.5638,0.3969,7.1249,0.3969,11.6788V77.042z"/>
+                                </svg>
+                            </a>
+                        </p>
+
+                            <button class="toggle-platform-header-navs dropdown-toggle button extra-small" aria-controls="platform-header-navs" aria-expanded="false" aria-haspopup="true" aria-label="Menu">
+                                <span>Menu</span>
+                            </button>
+                    </div>
+                </div>
+
+                <div id="platform-header-navs" class="platform-header-navs">
+                    <div class="wrapper">
+                        <nav class="platform-header-nav" aria-label="Main menu">
+                            <div class="platform-header-nav-tools">
+                                <ul class="langmenu">
+                                    <li class="dropdown nav-item">
+    <a role="button" class="dropdown-toggle nav-link" id="drop-down-68b9956dbcb0b68b9956db9bb24" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#">
+        English
+    </a>
+    <div class="dropdown-menu" aria-labelledby="drop-down-68b9956dbcb0b68b9956db9bb24">
+                <a class="dropdown-item" href="https://unccelearn.org/course/view.php?id=121&amp;lang=es" title="Language">Español</a>
+                <a class="dropdown-item" href="https://unccelearn.org/course/view.php?id=121&amp;lang=fr" title="Language">Français</a>
+                <a class="dropdown-item" href="https://unccelearn.org/course/view.php?id=121&amp;lang=pt_br" title="Language">Português</a>
+                <a class="dropdown-item" href="https://unccelearn.org/course/view.php?id=121&amp;lang=ru" title="Language">русский</a>
+                <a class="dropdown-item" href="https://unccelearn.org/course/view.php?id=121&amp;lang=zh_cn" title="Language">简体中文</a>
+    </div>
+</li>
+                                </ul>
+
+                                    <ul class="usermenu">
+                                        <a class="button extra-small grouped-first" href="https://unccelearn.org/theme/uncc/page_choosesignup.php"><span>Register</span><svg class="ccicon small" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/uncc/pix/sprite.svg#arrowright"></use></svg></a><a class="button extra-small grouped-last" href="https://unccelearn.org/login/index.php"><span>Log in</span><svg class="ccicon small" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/uncc/pix/sprite.svg#arrowright"></use></svg></a>
+                                    </ul>
+                            </div>
+
+                                <button class="toggle-platform-header-nav-main dropdown-toggle button extra-small" aria-controls="platform-header-nav-main" aria-expanded="false" aria-haspopup="true" aria-label="Menu">
+                                    <span>Menu</span>
+                                </button>
+
+                                <button class="toggle-platform-header-nav-main dropdown-toggle button extra-small" aria-controls="platform-header-nav-main" aria-expanded="false" aria-haspopup="true" aria-label="Menu">
+    <span>Menu</span>
+</button>
+
+<div id="platform-header-nav-main" class="platform-header-nav-main">
+    <ul>
+            <li>
+                <a class="nav-link " href="https://unccelearn.org/theme/uncc/page_about.php">About Us</a>
+            </li>
+            <li>
+                <a class="nav-link " href="https://unccelearn.org/courses/?language=en">Courses Catalog</a>
+            </li>
+            <li>
+                <a class="nav-link " href="https://unccelearn.org/theme/uncc/page_help.php?lang=en">Help</a>
+            </li>
+        <li>
+
+        </li>
+    </ul>
+</div>
+                        </nav>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <div id="page-wrapper">
+
+        <div id="page">
+            <div id="page-content">
+                <div id="region-main-box">
+
+
+                    <section id="region-main" >
+
+                        <span class="notifications" id="user-notifications"></span>
+                        <div role="main"><span id="maincontent"></span><div class="course-content"><div id="course-header" class="course-header overview">
+    <div class="top-bar">
+        <div class="wrapper">
+            <h1 lang="fr">Intégration du changement climatique dans les politiques nationale, sectorielle et locale</h1>
+
+        </div>
+    </div>
+
+
+    <div class="hero">
+        <div class="hero-container">
+
+            <img src="https://unccelearn.org/pluginfile.php/379643/format_unccelearn/background/0/BIG%20COURSE%20COVER.jpg" alt="" />
+        </div>
+    </div>
+
+</div><div class="overview" lang="fr">
+    <h2 class="sr-only">Overview</h2>
+    <div class="top">
+        <div class="wrapper">
+            <div class="details" lang="en">
+
+
+                        <a class="button white" href="https://unccelearn.org/login/index.php" id="overview_login">
+                            <span>Login to enrol</span>
+                            <svg class="ccicon small" aria-hidden="true">
+                                <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#arrowright"></use>
+                            </svg>
+                        </a>
+
+                    <a class="button white-border" href="https://unccelearn.org/pluginfile.php/379643/format_unccelearn/syllabus/0/Syllabus%20-%20Int%C3%A9gration%20du%20changement%20climatique%20dans%20les%20politiques%20nationales%2C%20locales%20et%20sectorielles.pdf" id="overview_syllabus_download">
+                        <span>Download syllabus</span></span>
+                        <svg class="ccicon" aria-hidden="true">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#download"></use>
+                        </svg>
+                    </a>
+
+                    <p class="thematic-areas">
+                            <svg class="ccicon left" title="Themes" aria-label="Themes"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#theme"></use></svg>
+                        <span><span>Climate change</span></span>
+                    </p>
+
+                    <p class="type">
+                        <svg class="ccicon left" title="Type" aria-label="Type">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#docs"></use>
+                        </svg>
+                        <span class="multilang" lang="fr">Self-paced courses</span>
+                    </p>
+
+                    <p class="time">
+                        <svg class="ccicon left" title="Time required" aria-label="Time required">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#time"></use>
+                        </svg>
+                        <span>4 hours</span>
+                    </p>
+
+                        <p class="certification">
+                            <svg class="ccicon left" title="Type" aria-label="Type">
+                                <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#certificate"></use>
+                            </svg>
+                            <span>With certification</span>
+                        </p>
+
+
+                    <p class="langs">
+                        <svg class="ccicon left" title="Languages" aria-label="Languages">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#language"></use>
+                        </svg>
+                        <span><span>French</span></span>
+                    </p>
+
+            </div>
+
+            <div class="summary">
+                <p dir="ltr" style="text-align: left;">Ce module développé par le Centre Régional AGRHYMET (CRA) dans le cadre du programme de formation du Master Changement Climatique et Développement Durable (CCDD) offre aux étudiants l’opportunité de revisiter les concepts clés du Changement climatique et de maitriser l’ensemble des étapes essentiels du processus de l’intégration du CC dans les politiques de développement et la planification budgétaire afin de favoriser la mise en œuvre des actions prioritaires d’adaptation et d’atténuation.&nbsp;<br></p>
+            </div>
+        </div>
+    </div>
+
+    <div class="content">
+
+            <div class="content-top">
+                <div class="wrapper">
+                    <div class="welcome">
+                        <p></p><h3>BIENVENUE !</h3><p>Les changements climatiques (CC) constituent une menace importante pour le développement socio-économique des pays en développement et risque de compromettre les chances de relever les défis de réduction de la pauvreté. A cet égard, les impacts potentiels du CC doivent être systématiquement prise en compte dans les politiques sociales et économiques, les projets de développement et les efforts d’aide internationale afin d’asseoir un développement résilient face au changement climatique. Cependant, pour les pays en développement, l’intégration du CC dans le processus de planification du développement représente encore un défi majeur.&nbsp;</p><p>Ce module développé par le Centre Régional AGRHYMET (CRA) dans le cadre du programme de formation du Master Changement Climatique et Développement Durable (CCDD) offre aux étudiants l’opportunité de revisiter les concepts clés du Changement climatique et de maitriser l’ensemble des étapes essentiels du processus de l’intégration du CC dans les politiques de développement et la planification budgétaire afin de favoriser la mise en œuvre des actions prioritaires d’adaptation et d’atténuation.&nbsp;</p><p>Aussi, ce module de formation offre des informations claires, concises et actualisées pour toute personne intéressée par l’acquisition d’une compréhension globale de la prise en compte du changement climatique dans les politiques de développement aux niveaux national, sectoriel et local.</p><p><br></p>
+                    </div>
+
+                    <div class="donate" lang="en">
+                        <div class="image">
+                            <img aria-hidden="true" alt="" src="/theme/uncc/pix/donate.jpg">
+                        </div>
+
+                        <div class="donate-content">
+                            <h3>Support climate change literacy</h3>
+                            <p>We want to continue our crucial journey to equip people with the skills and knowledge needed to make informed decisions, to act and to fight climate crisis.</p>
+                            <a href="https://www.uncclearn.org/donate/" class="button donate small" target="_blank">
+                                <span>Donate</span>
+                                <svg class="ccicon small" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/uncc/pix/sprite.svg#arrowright"></use></svg>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="what-you-will-learn">
+                <div class="wrapper">
+                    <h3> Ce que vous allez apprendre</h3>
+<p>L’objectif de ce cours est de former des cadres de haut niveau qui sauront, d’une part, valoriser et capitaliser les connaissances sur la science du climat pour les études d’impact, de vulnérabilité et d’adaptation face au CC, et d’autre part, appuyer l’intégration de la dimension CC dans les politiques et les stratégies nationales, régionales et locales de développement.</p>
+                </div>
+            </div>
+
+            <div class="glance">
+                <div class="wrapper">
+                    <h3>Cours en un coup d'œil</h3>
+<p></p><p><span lang="fr" xml:lang="fr">Ce cours est composé de quatre
+(4) leçons&nbsp;:</span></p><p></p>
+<ul><li><b><span lang="fr" xml:lang="fr">Comprendre
+le changement climatique et ses liens avec le développement</span></b><br> <span lang="fr" xml:lang="fr">Cette leçon propose une introduction sur la relation entre le changement
+climatique et le développement.</span></li>
+<li><b>L'intégration du <b>changement climatique</b> dans les politiques nationale, sectorielle, locale</b><br> <span lang="fr" xml:lang="fr">Cette
+leçon passe en revue tous les processus de prise en compte du changement
+climatique dans les politiques aux échelles nationale, sectorielle et locale.</span></li>
+<li><b>L’intégration du changement climatique dans le processus budgétaire</b><br><span lang="fr" xml:lang="fr">Cette
+leçon explique les points d’entrée et les étapes clés de la prise en compte du
+CC dans la formulation du budget national.</span></li>
+<li><b>L’intégration du changement climatique dans le système de suivi-évaluation</b><br> <span lang="fr" xml:lang="fr">Cette leçon aborde les contours du suivi-évaluation des actions des changements climatiques. Les concepts clés du suivi-évaluation sont d’abord définis.</span></li>
+<li><b>Quiz</b><br> <span lang="fr" xml:lang="fr">Un dernier quiz évaluant les connaissances acquises pendant le cours. Le quiz contient 10 questions.</span></li>
+</ul>
+                </div>
+            </div>
+
+
+
+            <div class="requirements">
+                <div class="wrapper">
+                    <h3>Exigences d'achèvement</h3>
+<p>Le cours est certifié. Le certificat de réussite sera disponible au téléchargement dans l'onglet «Certification» une fois que vous aurez suivi les 4 leçons et réussi le quiz à la fin du cours. Pour réussir le quiz, vous devez obtenir au moins 70% de bonnes réponses.</p><p>À la fin du cours, nous encourageons vivement les apprenants à répondre à l'enquête disponible sous l'onglet «Certification».&nbsp;<br></p>
+                </div>
+            </div>
+
+            <div class="credits">
+                <div class="wrapper">
+                    <h3>Partenaires et contributeurs</h3><p></p><p>Cette formation en ligne a été conçue dans le but d’apporter des réponses à des questions essentielles sur le « mainstreaming » du changement climatique dans les politiques et stratégies de développement. Ce module de formation a été développé par le CRA. Le format e-learning de ce cours a été réalisé par le CRA avec le coaching de l’UNITAR dans le cadre de UN CC:Learn.</p><p><br></p><ul><li><img alt="Alt" src="https://static.uncclearn.org/Agrhymet/cilss.jpg" width="200" height="150"><p><b><span>Comité permanent inter-État de lutte contre la sécheresse au Sahel</span></b><br><br></p></li><li><img alt="Alt" src="https://static.uncclearn.org/Agrhymet/uncclearn%20logo.jpg" width="200" height="150"><p><b>Le Partenariat unique pour l’apprentissage des Nations Unies sur les changements climatiques</b><br><br></p></li><li><img alt="Alt" src="https://static.uncclearn.org/Agrhymet/unitar%20logo.jpg" width="200" height="150"><p><b>Institut des Nations Unies pour la formation et la recherche</b><br><br></p></li></ul>
+                </div>
+            </div>
+    </div>
+
+    <div class="footer" lang="en">
+        <div class="wrapper">
+            <h3>Share this Course</h3>
+            <div class="links">
+                    <a href="https://www.facebook.com/sharer.php?u=https://unccelearn.org/course/view.php?id=121&amp;amp;page=course&amp;amp;page=overview&amp;amp;title=I just received my badge {{badgename}} in the course {{coursename}} at UN CC:eLearn." rel="noopener" target="_blank">
+                        <svg class="ccicon left large" aria-hidden="true">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#facebook"></use>
+                        </svg>
+                        <span>Share on Facebook</span>
+                    </a>
+
+                    <a href="https://twitter.com/intent/tweet?url=https://unccelearn.org/course/view.php?id=121&amp;amp;page=course&amp;amp;page=overview&amp;amp;text=I just received my badge {{badgename}} in the course {{coursename}} at UN CC:eLearn." rel="noopener" target="_blank">
+                        <svg class="ccicon left large" aria-hidden="true">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#twitter"></use>
+                        </svg>
+                        <span>Share on Twitter</span>
+                    </a>
+
+                    <a href="https://api.whatsapp.com/send?text=https://unccelearn.org/course/view.php?id=121&amp;amp;page=course" rel="noopener" target="_blank">
+                        <svg class="ccicon left large" aria-hidden="true">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#whatsapp"></use>
+                        </svg>
+                        <span>Share on Whatsapp</span>
+                    </a>
+
+                    <a href="https://www.linkedin.com/shareArticle?mini=true&amp;amp;url=https://unccelearn.org/course/view.php?id=121&amp;amp;page=course&amp;amp;title=I just received my badge {{badgename}} in the course {{coursename}} at UN CC:eLearn. rel="noopener" target="_blank">
+                        <svg class="ccicon left large" aria-hidden="true">
+                            <use xlink:href="https://unccelearn.org/theme/image.php/uncc/format_unccelearn/1753775342/sprite#linkedin"></use>
+                        </svg>
+                        <span>Share on Linkedin</span>
+                    </a>
+            </div>
+        </div>
+    </div>
+
+</div></div></div>
+
+
+                    </section>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+
+
+        <footer id="page-footer">
+            <div class="back-to-top smooth-scroll">
+                <a href="#platform-header">
+                    <svg class="ccicon left" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/theme/1753775342/sprite#arrowup"></use></svg>
+                    <span>Back to top</span>
+                </a>
+            </div>
+
+            <div class="page-footer-main">
+                <div class="wrapper">
+                    <div class="contact-nav">
+                        <h2>Contact us</h2>
+                            <a href="mailto:info@unccelearn.org" target="_top" title="Contact us by email">
+                                <svg class="ccicon left large" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/theme/1753775342/sprite#mail"></use></svg>
+                                <span>info@unccelearn.org</span>
+                            </a>
+                    </div>
+
+                    <div class="social-nav">
+                        <h2>Follow us</h2>
+                        <ul>
+                                <li>
+                                    <a href="https://www.facebook.com/uncclearn">
+                                        <svg class="ccicon left large" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/theme/1753775342/sprite#facebook"></use></svg>
+                                        <span>Facebook</span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="https://twitter.com/uncclearn">
+                                        <svg class="ccicon left large" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/theme/1753775342/sprite#twitter"></use></svg>
+                                        <span>X</span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="https://www.instagram.com/un_climatechange_learn/">
+                                        <svg class="ccicon left large" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/theme/1753775342/sprite#instagram"></use></svg>
+                                        <span>Instagram</span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="https://www.youtube.com/channel/UCNhN8uvdNTY9O8liLP-94mg/playlists">
+                                        <svg class="ccicon left large" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/theme/1753775342/sprite#youtube"></use></svg>
+                                        <span>Youtube</span>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="https://www.flickr.com/photos/146345277@N06/albums">
+                                        <svg class="ccicon left large" aria-hidden="true"><use xlink:href="https://unccelearn.org/theme/image.php/uncc/theme/1753775342/sprite#flickr"></use></svg>
+                                        <span>Flickr</span>
+                                    </a>
+                                </li>
+                        </ul>
+                    </div>
+
+                    <div class="support">
+                        <h2>With support by</h2>
+                        <a href="https://www.eda.admin.ch/sdc">
+                            <img alt="Swiss Agency for Development and Cooperation SDC" src="https://unccelearn.org/theme/uncc/pix/logo_swiss.svg">
+                        </a>
+                    </div>
+
+                </div>
+            </div>
+
+            <div class="credits">
+                <div class="wrapper">
+                    <a href="https://www.uncclearn.org/un-cclearn-partners">This platform has been developed in collaboration with UN CC:Learn Partners</a>
+                </div>
+            </div>
+        </footer>
+
+  <style>
+        .format-unccelearn.editing .section-card .activity-actions {
+            position: unset !important;
+        }
+    </style><script>
+//<![CDATA[
+var require = {
+    baseUrl : 'https://unccelearn.org/lib/requirejs.php/1753775342/',
+    // We only support AMD modules with an explicit define() statement.
+    enforceDefine: true,
+    skipDataMain: true,
+    waitSeconds : 0,
+
+    paths: {
+        jquery: 'https://unccelearn.org/lib/javascript.php/1753775342/lib/jquery/jquery-3.7.1.min',
+        jqueryui: 'https://unccelearn.org/lib/javascript.php/1753775342/lib/jquery/ui-1.13.2/jquery-ui.min',
+        jqueryprivate: 'https://unccelearn.org/lib/javascript.php/1753775342/lib/requirejs/jquery-private'
+    },
+
+    // Custom jquery config map.
+    map: {
+      // '*' means all modules will get 'jqueryprivate'
+      // for their 'jquery' dependency.
+      '*': { jquery: 'jqueryprivate' },
+
+      // 'jquery-private' wants the real jQuery module
+      // though. If this line was not here, there would
+      // be an unresolvable cyclic dependency.
+      jqueryprivate: { jquery: 'jquery' }
+    }
+};
+
+//]]>
+</script>
+<script src="https://unccelearn.org/lib/javascript.php/1753775342/lib/requirejs/require.min.js"></script>
+<script>
+//<![CDATA[
+M.util.js_pending("core/first");
+require(['core/first'], function() {
+require(['core/prefetch'])
+;
+
+require(['jquery', 'core/custom_interaction_events'], function($, CustomEvents) {
+    CustomEvents.define('#single_select68b9956db9bb23', [CustomEvents.events.accessibleChange]);
+    $('#single_select68b9956db9bb23').on(CustomEvents.events.accessibleChange, function() {
+        var ignore = $(this).find(':selected').attr('data-ignore');
+        if (typeof ignore === typeof undefined) {
+            $('#single_select_f68b9956db9bb22').submit();
+        }
+    });
+});
+;
+
+    require(['theme_boost/loader']);
+    require(['theme_boost/drawer'], function(mod) {
+        mod.init();
+    });
+;
+M.util.js_pending('core_courseformat/courseeditor'); require(['core_courseformat/courseeditor'], function(amd) {amd.setViewFormat("121", {"editing":false,"supportscomponents":false,"statekey":"1753775342_1756992877","overriddenStrings":[]}); M.util.js_complete('core_courseformat/courseeditor');});;
+M.util.js_pending('core_course/view'); require(['core_course/view'], function(amd) {amd.init(); M.util.js_complete('core_course/view');});;
+M.util.js_pending('theme_uncc/notification/coursecompleted'); require(['theme_uncc/notification/coursecompleted'], function(amd) {amd.init(); M.util.js_complete('theme_uncc/notification/coursecompleted');});;
+M.util.js_pending('core/notification'); require(['core/notification'], function(amd) {amd.init(379643, []); M.util.js_complete('core/notification');});;
+M.util.js_pending('core/log'); require(['core/log'], function(amd) {amd.setConfig({"level":"warn"}); M.util.js_complete('core/log');});;
+M.util.js_pending('core/page_global'); require(['core/page_global'], function(amd) {amd.init(); M.util.js_complete('core/page_global');});;
+M.util.js_pending('core/utility'); require(['core/utility'], function(amd) {M.util.js_complete('core/utility');});;
+M.util.js_pending('core/storage_validation'); require(['core/storage_validation'], function(amd) {amd.init(null); M.util.js_complete('core/storage_validation');});
+    M.util.js_complete("core/first");
+});
+//]]>
+</script>
+<script src="https://unccelearn.org/theme/javascript.php/uncc/1753775342/footer"></script>
+<script src="https://unccelearn.org/lib/javascript.php/1753775342/course/format/unccelearn/format.js"></script>
+<script>
+//<![CDATA[
+M.str = {"moodle":{"lastmodified":"Last modified","name":"Name","error":"Error","info":"Information","yes":"Yes","no":"No","cancel":"Cancel","confirm":"Confirm","areyousure":"Are you sure?","closebuttontitle":"Close","unknownerror":"Unknown error","file":"File","url":"URL","collapseall":"Collapse all","expandall":"Expand all"},"repository":{"type":"Type","size":"Size","invalidjson":"Invalid JSON string","nofilesattached":"No files attached","filepicker":"File picker","logout":"Logout","nofilesavailable":"No files available","norepositoriesavailable":"Sorry, none of your current repositories can return files in the required format.","fileexistsdialogheader":"File exists","fileexistsdialog_editor":"A file with that name has already been attached to the text you are editing.","fileexistsdialog_filemanager":"A file with that name has already been attached","renameto":"Rename to \"{$a}\"","referencesexist":"There are {$a} links to this file","select":"Select"},"admin":{"confirmdeletecomments":"Are you sure you want to delete the selected comment(s)?","confirmation":"Confirmation"},"format_unccelearn":{"confirmdelete":"Confirm delete?"},"debug":{"debuginfo":"Debug info","line":"Line","stacktrace":"Stack trace"},"langconfig":{"labelsep":": "}};
+//]]>
+</script>
+<script>
+//<![CDATA[
+(function() {M.util.help_popups.setup(Y);
+M.course.format.init_unccelearn(Y);
+ M.util.js_pending('random68b9956db9bb26'); Y.on('domready', function() { M.util.js_complete("init");  M.util.js_complete('random68b9956db9bb26'); });
+})();
+//]]>
+</script>
+
+
+</body></html>

--- a/tests/url_collector/test_uncclearn_collector.py
+++ b/tests/url_collector/test_uncclearn_collector.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from welearn_datastack.collectors.unccelearn_collector import UNCCeLearnURLCollector
+from welearn_datastack.data.db_models import Corpus
+
+
+class TestUNCCeLearnURLCollector(unittest.TestCase):
+    @patch("welearn_datastack.collectors.unccelearn_collector.get_new_https_session")
+    def test_collect(self, mock_get_session):
+        # Simuler une réponse HTTP
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = """
+        <div class="courses-list">
+            <article class="course-card" data-courseid="219">
+                <h3 class="card-title course-name">
+                    <a href="https://unccelearn.org/course/view.php?id=219&page=overview">Course 1</a>
+                </h3>
+            </article>
+            <article class="course-card" data-courseid="215">
+                <h3 class="card-title course-name">
+                    <a href="https://unccelearn.org/course/view.php?id=215&page=overview">Course 2</a>
+                </h3>
+            </article>
+        </div>
+        """
+        mock_response.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        # Initialiser le collecteur
+        corpus = Corpus(id=1, source_name="unccelearn")
+        collector = UNCCeLearnURLCollector(corpus=corpus)
+
+        # Appeler la méthode collect
+        result = collector.collect()
+
+        # Vérifier les résultats
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].url, "https://unccelearn.org/course/view.php?id=219")
+        self.assertEqual(result[1].url, "https://unccelearn.org/course/view.php?id=215")

--- a/tests/url_collector/test_uncclearn_collector.py
+++ b/tests/url_collector/test_uncclearn_collector.py
@@ -38,5 +38,11 @@ class TestUNCCeLearnURLCollector(unittest.TestCase):
 
         # Vérifier les résultats
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0].url, "https://unccelearn.org/course/view.php?id=219")
-        self.assertEqual(result[1].url, "https://unccelearn.org/course/view.php?id=215")
+        self.assertEqual(
+            result[0].url,
+            "https://unccelearn.org/course/view.php?id=219&page=overview&lang=en",
+        )
+        self.assertEqual(
+            result[1].url,
+            "https://unccelearn.org/course/view.php?id=215&page=overview&lang=en",
+        )

--- a/welearn_datastack/collectors/unccelearn_collector.py
+++ b/welearn_datastack/collectors/unccelearn_collector.py
@@ -37,7 +37,7 @@ class UNCCeLearnURLCollector(URLCollector):
         logger.info(f"Got {len(courses)} courses from UNCCeLearn")
         ret: List[WeLearnDocument] = []
 
-        url_template = "https://unccelearn.org/course/view.php?id=<ID_TO_REPLACE>"
+        url_template = "https://unccelearn.org/course/view.php?id=<ID_TO_REPLACE>&page=overview&lang=en"
 
         for course in courses:
             course_id = course.get("data-courseid")

--- a/welearn_datastack/collectors/unccelearn_collector.py
+++ b/welearn_datastack/collectors/unccelearn_collector.py
@@ -1,0 +1,50 @@
+import logging
+from typing import List
+
+from bs4 import BeautifulSoup
+from requests import Response
+
+from welearn_datastack.constants import HEADERS
+from welearn_datastack.data.db_models import Corpus, WeLearnDocument
+from welearn_datastack.data.url_collector import URLCollector
+from welearn_datastack.exceptions import NotEnoughData
+from welearn_datastack.utils_.http_client_utils import get_new_https_session
+
+logger = logging.getLogger(__name__)
+
+
+class UNCCeLearnURLCollector(URLCollector):
+    def __init__(self, corpus: Corpus | None) -> None:
+        self.corpus = corpus
+        self.base_url = "https://unccelearn.org/courses/"
+
+    def collect(self) -> List[WeLearnDocument]:
+        """
+        Collect the URLs of the books and their chapters.
+        :return:
+        """
+        # Get last books
+        logger.info("Getting last book from UNCCeLearn...")
+        client = get_new_https_session()
+        resp: Response = client.get(url=self.base_url, headers=HEADERS)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.content, features="html.parser")
+        courses = soup.find_all("article", class_="course-card")
+
+        if not courses:
+            raise NotEnoughData("There is no data from UNCCeLearn")
+
+        logger.info(f"Got {len(courses)} courses from UNCCeLearn")
+        ret: List[WeLearnDocument] = []
+
+        url_template = "https://unccelearn.org/course/view.php?id=<ID_TO_REPLACE>"
+
+        for course in courses:
+            course_id = course.get("data-courseid")
+            if not course_id:
+                continue
+            course_url = url_template.replace("<ID_TO_REPLACE>", course_id)
+
+            ret.append(WeLearnDocument(url=course_url))
+
+        return ret

--- a/welearn_datastack/modules/pdf_extractor.py
+++ b/welearn_datastack/modules/pdf_extractor.py
@@ -52,22 +52,27 @@ def _parse_tika_content(tika_content: dict) -> list[list[str]]:
 
 
 def extract_txt_from_pdf_with_tika(
-    pdf_content: io.BytesIO, tika_base_url: str
-) -> List[List[str]]:
+    pdf_content: io.BytesIO, tika_base_url: str, with_metadata: bool = False
+) -> List[List[str]] | tuple[List[List[str]], dict]:
     """
     Extract the text from a PDF document and return it as a list of strings for each page of the document and a list of
     strings for each page for a filtered document and the reference document (extracted with tika micro service)
 
     :param pdf_content: the PDF document content as a byte stream
     :param tika_base_url: the base URL of the Tika micro service
-    :return: Matrix of strings (list of list of strings) for each page of the document
+    :param with_metadata: if True, return a tuple with the refined document and the metadata extracted by Tika
+    :return: Matrix of strings (list of list of strings) for each page of the document or a tuple with the refined
+             body and the metadata extracted by Tika
     """
     tika_content = _send_pdf_to_tika(pdf_content, tika_base_url)
     pdf_content = _parse_tika_content(tika_content)
 
     refined_pdf_content = RefinedDocument(content=pdf_content)
 
-    return refined_pdf_content.body
+    if not with_metadata:
+        return refined_pdf_content.body
+    else:
+        return refined_pdf_content.body, tika_content
 
 
 def delete_non_printable_character(text: str) -> str:

--- a/welearn_datastack/nodes_workflow/URLCollectors/node_uncclearn_collect.py
+++ b/welearn_datastack/nodes_workflow/URLCollectors/node_uncclearn_collect.py
@@ -1,0 +1,46 @@
+import logging
+import os
+
+from welearn_datastack.collectors.unccelearn_collector import UNCCeLearnURLCollector
+from welearn_datastack.data.db_models import Corpus
+from welearn_datastack.nodes_workflow.URLCollectors.nodes_helpers.collect import (
+    insert_urls,
+)
+from welearn_datastack.utils_.database_utils import create_db_session
+
+log_level: int = logging.getLevelName(os.getenv("LOG_LEVEL", "INFO"))
+log_format: str = os.getenv(
+    "LOG_FORMAT", "[%(asctime)s][%(name)s][%(levelname)s] - %(message)s"
+)
+
+if not isinstance(log_level, int):
+    raise ValueError("Log level is not recognized : '%s'", log_level)
+
+logging.basicConfig(
+    level=logging.getLevelName(log_level),
+    format=log_format,
+)
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    logger.info("UNCCeLearn collector starting...")
+    session = create_db_session()
+    corpus: Corpus | None = (
+        session.query(Corpus).filter_by(source_name="unccelearn").one_or_none()
+    )
+
+    if corpus is None:
+        raise ValueError(f"Corpus unccelearn not found")
+
+    unccelearn_collector = UNCCeLearnURLCollector(corpus=corpus)
+
+    urls = unccelearn_collector.collect()
+
+    logger.info("URLs retrieved : '%s'", len(urls))
+    # insert_urls(
+    #     session=session,
+    #     urls=urls,
+    # )
+
+    logger.info("UNCCeLearn collector ended")

--- a/welearn_datastack/plugins/scrapers/__init__.py
+++ b/welearn_datastack/plugins/scrapers/__init__.py
@@ -5,10 +5,12 @@ from welearn_datastack.plugins.scrapers.conversation import ConversationCollecto
 from welearn_datastack.plugins.scrapers.oe_books import OpenEditionBooksCollector
 from welearn_datastack.plugins.scrapers.peerj import PeerJCollector
 from welearn_datastack.plugins.scrapers.plos import PlosCollector
+from welearn_datastack.plugins.scrapers.unccelearn import UNCCeLearnCollector
 
 plugins_scrape_list: List[Type[IPluginScrapeCollector]] = [
     ConversationCollector,
     PeerJCollector,
     PlosCollector,
     OpenEditionBooksCollector,
+    UNCCeLearnCollector,
 ]

--- a/welearn_datastack/plugins/scrapers/conversation.py
+++ b/welearn_datastack/plugins/scrapers/conversation.py
@@ -10,10 +10,6 @@ from welearn_datastack.data.scraped_welearn_document import ScrapedWeLearnDocume
 from welearn_datastack.plugins.interface import IPluginScrapeCollector
 from welearn_datastack.utils_.http_client_utils import get_new_https_session
 from welearn_datastack.utils_.scraping_utils import extract_property_from_html
-from welearn_datastack.utils_.text_stat_utils import (
-    predict_duration,
-    predict_readability,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/welearn_datastack/plugins/scrapers/unccelearn.py
+++ b/welearn_datastack/plugins/scrapers/unccelearn.py
@@ -1,0 +1,123 @@
+import io
+import logging
+import os
+import re
+from typing import List, Optional, Tuple
+
+from bs4 import BeautifulSoup, ResultSet  # type: ignore
+
+from welearn_datastack.data.scraped_welearn_document import ScrapedWeLearnDocument
+from welearn_datastack.plugins.interface import IPluginScrapeCollector
+from welearn_datastack.utils_.http_client_utils import get_new_https_session
+
+logger = logging.getLogger(__name__)
+
+
+def clean_str(string: str):
+    ret = re.sub(r"(\n|\t|\r)", "", string).strip()
+    return ret
+
+
+def format_news_keywords(raw_news_keywords: Optional[str]) -> List[str]:
+    if raw_news_keywords is None:
+        return []
+    elif "," in raw_news_keywords:
+        keywords = raw_news_keywords.split(",")
+        return [keyword.strip() for keyword in keywords]
+    else:
+        return [raw_news_keywords.strip()]
+
+
+class UNCCeLearnCollector(IPluginScrapeCollector):
+    related_corpus = "unccelearn"
+
+    def __init__(self):
+        super().__init__()
+        self.timeout = int(os.environ.get("SCRAPING_TIMEOUT", 60))
+        self.tika_address = os.getenv("TIKA_ADDRESS", "http://localhost:9998")
+
+    def _get_metadata_from_tika(self, content: io.BytesIO) -> dict:
+        with get_new_https_session() as tika_client:
+            resp = tika_client.put(
+                url=f"{self.tika_address}/meta",
+                data=content,
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "text/html; charset=utf-8",
+                },
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    def _get_details(self, soup: BeautifulSoup) -> dict:
+        page_details = soup.find("div", class_="details")
+        details: dict = {}
+        if not page_details:
+            return details
+        theme = page_details.find("p", class_="theme")
+        if theme:
+            details["theme"] = theme.text.strip()
+        # TODO: How to convert this duration to a number of seconds ?
+        duration = page_details.find("p", class_="time")
+        if duration:
+            details["duration"] = duration.text.strip()
+
+        # TODO: Convert it to a boolean
+        certification = page_details.find("p", class_="certification")
+        if certification:
+            details["certification"] = certification.text.strip()
+
+        # TODO: Maybe there is a typology of course here ? Or just classical "type"
+        type = page_details.find("p", class_="type")
+        if type:
+            details["course_type"] = type.text.strip()
+        return details
+
+    def _get_content(self, soup: BeautifulSoup) -> str:
+        pass
+
+    def _scrape_url(self, url: str) -> ScrapedWeLearnDocument:
+        logger.info("Scraping url : '%s'", url)
+
+        with get_new_https_session() as client:
+            resp = client.get(url=url, timeout=self.timeout)
+            resp.raise_for_status()
+            tika_metadata = self._get_metadata_from_tika(io.BytesIO(resp.content))
+            doc_title = tika_metadata.get("dc:title", "")
+            doc_desc = tika_metadata.get("dc:description", "")
+
+            soup = BeautifulSoup(resp.content, features="html.parser")
+            details = self._get_details(soup)
+            details["image"] = tika_metadata.get("og:image", "")
+            details["keywords"] = format_news_keywords(
+                tika_metadata.get("keywords", None)
+            )
+            details["type"] = "MOOC"
+
+            content = self._get_content(soup)
+
+            return ScrapedWeLearnDocument(
+                document_url=url,
+                document_title=doc_title,
+                document_desc=doc_desc,
+                document_content=content,
+                document_details=details,
+                document_corpus=self.related_corpus,
+            )
+
+    def run(self, urls: List[str]) -> Tuple[List[ScrapedWeLearnDocument], List[str]]:
+        logger.info("Running UNCCeLearnCollector plugin")
+        ret: List[ScrapedWeLearnDocument] = []
+        error_docs: List[str] = []
+        for url in urls:
+            try:
+                ret.append(self._scrape_url(url))
+            except Exception as e:
+                logger.exception(
+                    "Error while scraping url,\n url: '%s' \nError: %s", url, e
+                )
+                error_docs.append(url)
+                continue
+        logger.info("UNCCeLearnCollector plugin finished, %s urls scraped", len(ret))
+        return ret, error_docs

--- a/welearn_datastack/plugins/scrapers/unccelearn.py
+++ b/welearn_datastack/plugins/scrapers/unccelearn.py
@@ -1,14 +1,26 @@
+import datetime
 import io
 import logging
+import math
 import os
 import re
+import time
 from typing import List, Optional, Tuple
 
 from bs4 import BeautifulSoup, ResultSet  # type: ignore
 
+from welearn_datastack.constants import HEADERS
 from welearn_datastack.data.scraped_welearn_document import ScrapedWeLearnDocument
+from welearn_datastack.modules.pdf_extractor import (
+    delete_accents,
+    delete_non_printable_character,
+    extract_txt_from_pdf_with_tika,
+    remove_hyphens,
+    replace_ligatures,
+)
 from welearn_datastack.plugins.interface import IPluginScrapeCollector
 from welearn_datastack.utils_.http_client_utils import get_new_https_session
+from welearn_datastack.utils_.scraping_utils import remove_extra_whitespace
 
 logger = logging.getLogger(__name__)
 
@@ -36,75 +48,156 @@ class UNCCeLearnCollector(IPluginScrapeCollector):
         self.timeout = int(os.environ.get("SCRAPING_TIMEOUT", 60))
         self.tika_address = os.getenv("TIKA_ADDRESS", "http://localhost:9998")
 
-    def _get_metadata_from_tika(self, content: io.BytesIO) -> dict:
+    def _get_metadata_from_tika(self, content: io.BytesIO, content_type: str) -> dict:
         with get_new_https_session() as tika_client:
             resp = tika_client.put(
                 url=f"{self.tika_address}/meta",
                 data=content,
                 headers={
                     "Accept": "application/json",
-                    "Content-Type": "text/html; charset=utf-8",
+                    "Content-Type": content_type,
                 },
                 timeout=self.timeout,
             )
             resp.raise_for_status()
             return resp.json()
 
+    def _convert_duration_to_seconds(self, duration_str: str) -> int:
+        """
+        Convert a duration string like "3 hours", "3.5 hours" or "3-4 hours" to seconds.
+
+        :param duration_str: The duration string to convert.
+        :return: The duration in seconds.
+        """
+        avg_symbol = "-"
+
+        duration_str = duration_str.replace("hours", "").strip()
+
+        if "," in duration_str:
+            duration_str = duration_str.replace(",", ".")
+
+        if avg_symbol in duration_str:
+            course_duration_in_hour = float(duration_str.split("-")[0])
+            course_duration_in_hour += 0.5
+        else:
+            course_duration_in_hour = float(duration_str)
+
+        course_duration_in_seconds = course_duration_in_hour * 3600
+        return int(course_duration_in_seconds)
+
     def _get_details(self, soup: BeautifulSoup) -> dict:
+        """
+        Get the details of the course from the page
+        :param soup: The BeautifulSoup object of the page
+        :return: A dictionary with the details of the course
+        """
         page_details = soup.find("div", class_="details")
         details: dict = {}
         if not page_details:
             return details
-        theme = page_details.find("p", class_="theme")
+        theme = page_details.find("p", class_="thematic-areas")
         if theme:
-            details["theme"] = theme.text.strip()
-        # TODO: How to convert this duration to a number of seconds ?
+            details["theme"] = theme.text.strip().lower()
+
         duration = page_details.find("p", class_="time")
         if duration:
-            details["duration"] = duration.text.strip()
+            details["duration"] = self._convert_duration_to_seconds(
+                duration.text.strip()
+            )
 
-        # TODO: Convert it to a boolean
+        # Convert into boolean this property
         certification = page_details.find("p", class_="certification")
         if certification:
-            details["certification"] = certification.text.strip()
+            details["certifying"] = (
+                certification.text.strip().lower() == "with certification"
+            )
 
-        # TODO: Maybe there is a typology of course here ? Or just classical "type"
         type = page_details.find("p", class_="type")
         if type:
-            details["course_type"] = type.text.strip()
+            details["course-type"] = type.text.strip().lower()
         return details
 
-    def _get_content(self, soup: BeautifulSoup) -> str:
-        pass
+    def _get_pdf(self, pdf_url: str):
+        with get_new_https_session() as client:
+            resp = client.get(url=pdf_url, headers=HEADERS, timeout=self.timeout)
+            resp.raise_for_status()
+            return resp.content
+
+    def _get_content_and_file_metadata(self, soup: BeautifulSoup) -> tuple[str, dict]:
+        """
+        Get the content and the metadata of the PDF file
+        :param soup: The BeautifulSoup object of the page
+        :return: A tuple with the content and the metadata of the PDF file
+        """
+        pdf_url = soup.find("a", id="overview_syllabus_download").get("href", "")
+
+        pdf_content_bytes = self._get_pdf(pdf_url)
+
+        pdf_content, tika_metadata = extract_txt_from_pdf_with_tika(
+            pdf_content_bytes, tika_base_url=self.tika_address, with_metadata=True
+        )
+
+        # Delete non printable characters
+        pdf_content = [
+            [delete_non_printable_character(word) for word in page]
+            for page in pdf_content
+        ]
+
+        pages = []
+        for content in pdf_content:
+            page_text = " ".join(content)
+            page_text = replace_ligatures(page_text)
+            page_text = remove_hyphens(page_text)
+            page_text = delete_accents(page_text)
+
+            pages.append(page_text)
+        ret = remove_extra_whitespace(" ".join(pages))
+
+        produced_date = tika_metadata.get("pdf:docinfo:created", "")
+        produced_timestamp = None
+        if produced_date:
+            fmt = "%Y-%m-%dT%H:%M:%SZ"
+            # Convert into timestamp
+            produced_timestamp = math.floor(
+                time.mktime(datetime.datetime.strptime(produced_date, fmt).timetuple())
+            )
+
+        file_metadata = {
+            "produced_date": produced_timestamp if produced_date else None,
+        }
+
+        return ret, file_metadata
 
     def _scrape_url(self, url: str) -> ScrapedWeLearnDocument:
         logger.info("Scraping url : '%s'", url)
 
-        with get_new_https_session() as client:
-            resp = client.get(url=url, timeout=self.timeout)
-            resp.raise_for_status()
-            tika_metadata = self._get_metadata_from_tika(io.BytesIO(resp.content))
-            doc_title = tika_metadata.get("dc:title", "")
-            doc_desc = tika_metadata.get("dc:description", "")
+        client = get_new_https_session()
+        resp = client.get(url=url, timeout=self.timeout)
+        resp.raise_for_status()
+        tika_metadata = self._get_metadata_from_tika(
+            io.BytesIO(resp.content), content_type="text/html; charset=utf-8"
+        )
+        doc_title = tika_metadata.get("dc:title", "")
+        doc_desc = tika_metadata.get("dc:description", "")
 
-            soup = BeautifulSoup(resp.content, features="html.parser")
-            details = self._get_details(soup)
-            details["image"] = tika_metadata.get("og:image", "")
-            details["keywords"] = format_news_keywords(
-                tika_metadata.get("keywords", None)
-            )
-            details["type"] = "MOOC"
+        soup = BeautifulSoup(resp.content, features="html.parser")
+        details = self._get_details(soup)
+        details["image"] = tika_metadata.get("og:image", "")
+        details["keywords"] = format_news_keywords(tika_metadata.get("keywords", None))
+        details["type"] = "MOOC"
 
-            content = self._get_content(soup)
+        content, file_md = self._get_content_and_file_metadata(soup)
 
-            return ScrapedWeLearnDocument(
-                document_url=url,
-                document_title=doc_title,
-                document_desc=doc_desc,
-                document_content=content,
-                document_details=details,
-                document_corpus=self.related_corpus,
-            )
+        details.update(file_md)
+
+        return ScrapedWeLearnDocument(
+            document_url=url,
+            document_title=doc_title,
+            document_desc=doc_desc,
+            document_content=content,
+            document_details=details,
+            document_corpus=self.related_corpus,
+        )
 
     def run(self, urls: List[str]) -> Tuple[List[ScrapedWeLearnDocument], List[str]]:
         logger.info("Running UNCCeLearnCollector plugin")


### PR DESCRIPTION
This pull request introduces a new URL collector and scraping plugin for UN CC:Learn (unccelearn.org) courses, along with comprehensive tests and workflow integration. The main changes include implementing the `UNCCeLearnURLCollector` to gather course URLs, a detailed scraping plugin to extract course metadata and content (including PDF extraction with Tika), and corresponding tests to ensure robustness. The workflow for collecting URLs is also integrated into the nodes system.

**New UN CC:Learn URL Collector and Scraper**

* Implemented `UNCCeLearnURLCollector` to fetch course URLs from unccelearn.org, with error handling for missing data and logging for traceability. (welearn_datastack/collectors/unccelearn_collector.py)
* Added a new scraping plugin `UNCCeLearnCollector` that extracts detailed course information, including metadata from HTML and associated PDF syllabus files using Tika, with robust parsing and cleaning logic. (welearn_datastack/plugins/scrapers/unccelearn.py)
* Updated the PDF extraction utility to support returning both extracted text and metadata, enabling richer downstream processing. (welearn_datastack/modules/pdf_extractor.py)

**Testing and Workflow Integration**

* Added comprehensive tests for both the URL collector and the scraping plugin, covering normal and error scenarios, content extraction, and metadata parsing. (tests/url_collector/test_uncclearn_collector.py, tests/document_collector_hub/plugins_test/test_unccelearn.py) [[1]](diffhunk://#diff-ae5fc68845e15d39c31c0d2ba30f688529d6bb0ddebf127377fdab6eb1fecbf5R1-R48) [[2]](diffhunk://#diff-dd827a02b62299868d239de642a638534c61451e6b188f1428d25c5cb3900525R1-R241)
* Integrated the new collector into the workflow system via a new node, including logging and database session management. (welearn_datastack/nodes_workflow/URLCollectors/node_uncclearn_collect.py)

**Minor Cleanup**

* Removed unused imports in the conversation scraper module. (welearn_datastack/plugins/scrapers/conversation.py)