### PR TITLE
Fix/qdrant collection selection

### DIFF
--- a/tests/qdrant_syncronizer/test_qdrant_handler.py
+++ b/tests/qdrant_syncronizer/test_qdrant_handler.py
@@ -134,3 +134,28 @@ class TestQdrantHandler(unittest.TestCase):
             "collection_welearn_mul_mulembmodel": {doc_id1},
         }
         self.assertDictEqual(dict(collections_names), expected)
+
+    def test_should_handle_multiple_slices_for_same_collection_with_multi_lingual_collection_and_gibberish(
+        self,
+    ):
+        self.client.create_collection(
+            collection_name="collection_welearn_mul_mulembmodel_og",
+            vectors_config=models.VectorParams(
+                size=50, distance=models.Distance.COSINE
+            ),
+        )
+
+        doc_id0 = uuid.uuid4()
+        doc_id1 = uuid.uuid4()
+        qdrant_connector = self.client
+        fake_slice0 = FakeSlice(doc_id0, embedding_model_name="english-embmodel")
+        fake_slice1 = FakeSlice(doc_id0, embedding_model_name="english-embmodel")
+
+        fake_slice1.order_sequence = 1
+
+        fake_slice2 = FakeSlice(doc_id1, embedding_model_name="mulembmodel")
+        fake_slice2.document.lang = "pt"
+
+        slices = [fake_slice0, fake_slice1, fake_slice2]
+        collections_names = classify_documents_per_collection(qdrant_connector, slices)
+        self.assertNotIn("collection_welearn_mul_mulembmodel_og", collections_names)

--- a/welearn_datastack/modules/qdrant_handler.py
+++ b/welearn_datastack/modules/qdrant_handler.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 from typing import Collection, Dict, List, Set, Type
 from uuid import UUID
 
@@ -35,17 +34,18 @@ def classify_documents_per_collection(
         lang = dslice.document.lang
         model = dslice.embedding_model.title
         collection_name = None
-        # Check multilingual
+
+        # Check multilingual or mono lingual
         for cn in collections_names_in_qdrant:
             multilingual_collection = f"collection_welearn_mul_{model}"
+            mono_collection = f"collection_welearn_{lang}_{model}"
+
             if cn == multilingual_collection:
                 collection_name = multilingual_collection
-
-        # Check monolingual
-        for cn in collections_names_in_qdrant:
-            mono_collection = f"collection_welearn_{lang}_{model}"
+                break
             if cn == mono_collection:
                 collection_name = mono_collection
+                break
 
         if not collection_name:
             logger.error(

--- a/welearn_datastack/modules/qdrant_handler.py
+++ b/welearn_datastack/modules/qdrant_handler.py
@@ -9,9 +9,7 @@ from qdrant_client.grpc import UpdateResult
 from qdrant_client.http.models import models
 
 from welearn_datastack.data.db_models import DocumentSlice
-from welearn_datastack.exceptions import (
-    ErrorWhileDeletingChunks,
-)
+from welearn_datastack.exceptions import ErrorWhileDeletingChunks
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +77,6 @@ def delete_points_related_to_document(
     """
     logger.info("Deletion started")
     logger.debug(f"Deleting points related to {documents_ids} in {collection_name}")
-    op_res = None
 
     try:
         op_res = qdrant_connector.delete(

--- a/welearn_datastack/modules/qdrant_handler.py
+++ b/welearn_datastack/modules/qdrant_handler.py
@@ -34,20 +34,15 @@ def classify_documents_per_collection(
         lang = dslice.document.lang
         model = dslice.embedding_model.title
         collection_name = None
+        multilingual_collection = f"collection_welearn_mul_{model}"
+        mono_collection = f"collection_welearn_{lang}_{model}"
 
         # Check multilingual or mono lingual
-        for cn in collections_names_in_qdrant:
-            multilingual_collection = f"collection_welearn_mul_{model}"
-            mono_collection = f"collection_welearn_{lang}_{model}"
-
-            if cn == multilingual_collection:
-                collection_name = multilingual_collection
-                break
-            if cn == mono_collection:
-                collection_name = mono_collection
-                break
-
-        if not collection_name:
+        if multilingual_collection in collections_names_in_qdrant:
+            collection_name = multilingual_collection
+        elif mono_collection in collections_names_in_qdrant:
+            collection_name = mono_collection
+        else:
             logger.error(
                 f"Collection {collection_name} not found in Qdrant, slice {dslice.id} ignored",
             )

--- a/welearn_datastack/nodes_workflow/QdrantSyncronizer/qdrant_syncronizer.py
+++ b/welearn_datastack/nodes_workflow/QdrantSyncronizer/qdrant_syncronizer.py
@@ -114,6 +114,7 @@ def main() -> None:
 
         # Iterate on each collection
         for collection_name in documents_per_collection:
+            logger.info(f"We working on collection : {collection_name}")
             # We need to delete all points related to the documents in the collection for avoiding duplicates
             del_res = delete_points_related_to_document(
                 collection_name=collection_name,


### PR DESCRIPTION
This pull request improves the logic for classifying document slices per Qdrant collection, updates related tests, and makes minor code cleanups. The main focus is on more accurately mapping document slices to their respective collections, especially for multilingual and monolingual scenarios.

**Improvements to collection classification logic:**

* Refactored the `classify_documents_per_collection` function in `qdrant_handler.py` to use a more robust approach for determining the correct collection for each document slice. The function now checks for both multilingual and monolingual collection naming patterns, and logs an error if a matching collection is not found.
* Updated the return type initialization in `classify_documents_per_collection` from a `defaultdict` to a standard dictionary for clarity and consistency.

**Testing enhancements:**

* Added a new test, `test_should_handle_multiple_slices_for_same_collection_with_multi_lingual_collection_and_gibberish`, to cover scenarios where document slices belong to multilingual collections or collections with unexpected names, ensuring the new classification logic works as intended.

**Logging and code cleanup:**

* Added an info-level log statement in `qdrant_syncronizer.py` to indicate which collection is being processed during synchronization.
* Simplified import statements and removed unused variables in `qdrant_handler.py` for better code hygiene. [[1]](diffhunk://#diff-f325d021297cc196321fcff0871f38da95d25c5965c8460160cb1e3b139e9323L12-R12) [[2]](diffhunk://#diff-f325d021297cc196321fcff0871f38da95d25c5965c8460160cb1e3b139e9323L76)