### PR TITLE
feat(wikipedia): enhance redirection handling and add unit test for r…

### DIFF
--- a/tests/wikipedia_updater/test_wikipedia_updater.py
+++ b/tests/wikipedia_updater/test_wikipedia_updater.py
@@ -186,6 +186,18 @@ class TestWikipediaUpdater(unittest.TestCase):
         self.assertFalse(is_redirection(doc))
         self.assertEqual(mock_session.head.call_count, 2)
 
-
-if __name__ == "__main__":
-    unittest.main()
+    @patch("welearn_datastack.modules.wikipedia_updater.get_new_https_session")
+    def test_is_redirection_true_with_weird_text(self, mock_get_session):
+        """Should return True if the first HEAD returns 307 (redirection)."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 307
+        mock_response.raise_for_status.return_value = None
+        mock_session.head.return_value = mock_response
+        mock_get_session.return_value = mock_session
+        doc = WeLearnDocument(title="Bossons/Blécherette", lang="fr")
+        self.assertTrue(is_redirection(doc))
+        self.assertEqual(
+            mock_session.head.call_args[1]["url"],
+            "https://fr.wikipedia.org/w/rest.php/v1/page/Bossons%2FBl%C3%A9cherette/with_html",
+        )

--- a/welearn_datastack/modules/wikipedia_updater.py
+++ b/welearn_datastack/modules/wikipedia_updater.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from urllib.parse import quote_plus
 
 import requests  # type: ignore
 from welearn_database.data.models import WeLearnDocument
@@ -53,7 +54,7 @@ def is_redirection(document: WeLearnDocument) -> bool:
         raise ValueError("Document language is required")
 
     lang = document.lang
-    page_title = document.title
+    page_title = quote_plus(document.title)
 
     session = get_new_https_session()
     url = f"https://{lang}.wikipedia.org/w/rest.php/v1/page/{page_title}/with_html"

--- a/welearn_datastack/nodes_workflow/WikipediaUpdater/wikipedia_updater.py
+++ b/welearn_datastack/nodes_workflow/WikipediaUpdater/wikipedia_updater.py
@@ -67,7 +67,7 @@ def main() -> None:
                     ErrorRetrieval(
                         document_id=wld.id,
                         http_error_code=307,
-                        error_info="Wikipedia update determine this document is a redirection, not a content page",
+                        error_info="Wikipedia updater determine this document is a redirection, not a content page",
                     ),
                 )
                 continue


### PR DESCRIPTION
This pull request improves the handling of Wikipedia page titles with special characters because if you take the very specific example of https://fr.wikipedia.org/wiki/Bossons%2FBl%C3%A9cherette you can see a '/' in the name and when the API is requested by the default behavior it crash

**Bug Fixes & Improvements:**

* The `is_redirection` function now uses `quote_plus` to properly encode Wikipedia page titles, ensuring correct URL formation for titles with special characters. [[1]](diffhunk://#diff-d2e93b97721fd0a4764fbbd2d2fc51ebd0d6eebabe69162fa948da07ad3fb1c9R3) [[2]](diffhunk://#diff-d2e93b97721fd0a4764fbbd2d2fc51ebd0d6eebabe69162fa948da07ad3fb1c9L56-R57)

**Testing Enhancements:**

* Added a new unit test (`test_is_redirection_true_with_weird_text`) to verify that redirections (HTTP 307) are correctly detected, especially for page titles containing special characters.

**Error Message Update:**

* Updated the error message for redirection detection to clarify that the Wikipedia updater, not the update process, determines if a document is a redirection.…edirection detection