### PR TITLE
fix: rename content attribute to full_content and update return type …

### DIFF
--- a/tests/document_collector_hub/plugins_test/test_open_alex.py
+++ b/tests/document_collector_hub/plugins_test/test_open_alex.py
@@ -202,6 +202,7 @@ class TestOpenAlexCollector(unittest.TestCase):
     @patch("welearn_datastack.plugins.rest_requesters.open_alex.get_pdf_content")
     def test_update_welearn_document_returns_expected_document(self, mock_pdf):
         openalex_result = build_openalex_result()
+        mock_pdf.return_value = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
         wrapper = WrapperRawData(document=self.welearn_doc, raw_data=openalex_result)
         doc = self.collector._update_welearn_document(wrapper)
         self.assertEqual(doc.title, openalex_result.title)

--- a/tests/document_collector_hub/plugins_test/test_open_alex.py
+++ b/tests/document_collector_hub/plugins_test/test_open_alex.py
@@ -302,3 +302,39 @@ class TestOpenAlexCollector(unittest.TestCase):
         self.assertIn(
             "Error while trying to get contents from OpenAlex API", result[0].error_info
         )
+
+    @patch("welearn_datastack.plugins.rest_requesters.open_alex.get_pdf_content")
+    def test__resolve_full_content_from_pdf(self, mock_get_pdf_content):
+        mock_get_pdf_content.return_value = "content of the document from a fake PDF"
+        openalex_result = build_openalex_result()
+        wrapper = WrapperRawData(document=self.welearn_doc, raw_data=openalex_result)
+        description = "fake description"
+        result = self.collector._resolve_full_content(
+            document_desc=description, wrapper=wrapper
+        )
+        self.assertEqual(result[0], "content of the document from a fake PDF")
+        self.assertTrue(result[1])
+
+    @patch("welearn_datastack.plugins.rest_requesters.open_alex.get_pdf_content")
+    def test__resolve_full_content_from_desc(self, mock_get_pdf_content):
+        openalex_result = build_openalex_result()
+        wrapper = WrapperRawData(document=self.welearn_doc, raw_data=openalex_result)
+        wrapper.raw_data.best_oa_location.pdf_url = None  # Simulate no PDF available
+        description = "fake description"
+        result = self.collector._resolve_full_content(
+            document_desc=description, wrapper=wrapper
+        )
+        self.assertEqual(result[0], description)
+        self.assertFalse(result[1])
+
+    @patch("welearn_datastack.plugins.rest_requesters.open_alex.get_pdf_content")
+    def test__resolve_full_content_exception_from_pdf_get(self, mock_get_pdf_content):
+        mock_get_pdf_content.side_effect = Exception("PDF download error")
+        openalex_result = build_openalex_result()
+        wrapper = WrapperRawData(document=self.welearn_doc, raw_data=openalex_result)
+        description = "fake description"
+        result = self.collector._resolve_full_content(
+            document_desc=description, wrapper=wrapper
+        )
+        self.assertEqual(result[0], description)
+        self.assertFalse(result[1])

--- a/welearn_datastack/plugins/rest_requesters/open_alex.py
+++ b/welearn_datastack/plugins/rest_requesters/open_alex.py
@@ -273,7 +273,7 @@ class OpenAlexCollector(IPluginRESTCollector):
         Get the full content of the document. If the PDF is available and can be retrieved, extract the content from the PDF. Otherwise, use the description as the content.
         :param document_desc: Description of the document to use as content if the PDF is not available or cannot be retrieved
         :param wrapper: WrapperRawData containing the raw data of the document to get the content from
-        :return: tuple containing a flag indicating if the content is from the PDF and the content of the document
+        :return: tuple containing the content of the document and a flag indicating if the content is from the PDF
         """
         document_content = document_desc
 

--- a/welearn_datastack/plugins/rest_requesters/open_alex.py
+++ b/welearn_datastack/plugins/rest_requesters/open_alex.py
@@ -197,7 +197,7 @@ class OpenAlexCollector(IPluginRESTCollector):
         document_details = self._build_details(document_url, pdf_flag, wrapper)
         wrapper.document.title = wrapper.raw_data.title
         wrapper.document.description = document_desc
-        wrapper.document.content = document_content
+        wrapper.document.full_content = document_content
         wrapper.document.details = document_details
         wrapper.document.external_id = self._get_doi(wrapper)
         wrapper.document.external_id_type = ExternalIdType.DOI
@@ -268,7 +268,7 @@ class OpenAlexCollector(IPluginRESTCollector):
 
     def _resolve_full_content(
         self, document_desc: str | Any, wrapper: WrapperRawData
-    ) -> tuple[bool, str | Any]:
+    ) -> tuple[str, bool]:
         """
         Get the full content of the document. If the PDF is available and can be retrieved, extract the content from the PDF. Otherwise, use the description as the content.
         :param document_desc: Description of the document to use as content if the PDF is not available or cannot be retrieved


### PR DESCRIPTION
This pull request makes targeted changes to how document content is handled in the OpenAlex REST requester plugin. The main improvements involve updating the attribute used for storing full document content and clarifying the return type of a helper method.

**Document content handling:**

* Changed assignment from `wrapper.document.content` to `wrapper.document.full_content` in `_update_welearn_document`, ensuring that the full content is stored in the correct attribute.

**Method signature update:**

* Updated the return type and order of the tuple in `_resolve_full_content` to return `(str, bool)` instead of `(bool, str | Any)`, providing clearer semantics and consistency with usage.