### PR TITLE
Feature/add diamond oa on open alex

### DIFF
--- a/tests/url_collector/test_openalex_collector.py
+++ b/tests/url_collector/test_openalex_collector.py
@@ -52,7 +52,7 @@ class TestOpenAlexURLCollector(TestCase):
         )
         self.assertEqual(filter_as_dict["is_retracted"], "false")
         self.assertEqual(filter_as_dict["language"], "languages/en|languages/fr")
-        self.assertEqual(filter_as_dict["open_access.oa_status"], "gold")
+        self.assertEqual(filter_as_dict["open_access.oa_status"], "gold|diamond")
         self.assertEqual(
             filter_as_dict["primary_location.source.id"],
             "!s202381698|s4306402512|s1983995261|s4210178049|s4210220408|s4210231901|s4220651631|s4220650797|s4210221150|s4220651226|s86033158|s154343897|s103870658|s197939330|s4404663781|s46544255|s2004986",

--- a/welearn_datastack/collectors/open_alex_collector.py
+++ b/welearn_datastack/collectors/open_alex_collector.py
@@ -49,7 +49,7 @@ class OpenAlexURLCollector(URLCollector, ABC):
 
         # Gold because it's better https://u-paris.fr/bibliotheques/wp-content/uploads/sites/34/2021/02/06-OPEN-ACCESS.pdf
         # But could be extended to hybrid
-        oa_status = "gold"
+        oa_status = "gold|diamond"
 
         # Open Alex code for source we aldready have
         # In this order :


### PR DESCRIPTION
This pull request updates the OpenAlex collector to support both "gold" and "diamond" open access statuses instead of just "gold". This change ensures that queries and related tests now consider both types of open access publications.

**Open Access Status Update:**

* Modified the `_generate_api_query_params` method in `open_alex_collector.py` to set `oa_status` to `"gold|diamond"` instead of just `"gold"`.
* Updated the corresponding test in `test_openalex_collector.py` to assert that the `open_access.oa_status` filter is `"gold|diamond"`.