### PR TITLE
Fix/openalex timeout

### DIFF
--- a/welearn_datastack/plugins/rest_requesters/open_alex.py
+++ b/welearn_datastack/plugins/rest_requesters/open_alex.py
@@ -395,7 +395,7 @@ class OpenAlexCollector(IPluginRESTCollector):
         ret: list[WrapperRetrieveDocument] = []
         page_length = 50
         sub_batches: batched[WeLearnDocument] = batched(documents, page_length)
-        http_client = get_new_https_session()
+        http_client = get_new_https_session(retry_total=2)
 
         for sub_batch in sub_batches:
             urls_docs = {d.url: d for d in sub_batch}

--- a/welearn_datastack/plugins/rest_requesters/open_alex.py
+++ b/welearn_datastack/plugins/rest_requesters/open_alex.py
@@ -1,4 +1,3 @@
-import io
 import json
 import logging
 import os
@@ -13,7 +12,6 @@ from welearn_database.data.models import WeLearnDocument
 
 from welearn_datastack.constants import (
     AUTHORIZED_LICENSES,
-    HEADERS,
     HTTPS_CREATIVE_COMMONS,
     OPEN_ALEX_BASE_URL,
     PUBLISHERS_TO_AVOID,
@@ -31,25 +29,16 @@ from welearn_datastack.exceptions import (
     ClosedAccessContent,
     ManagementExceptions,
     NotEnoughData,
-    PDFFileSizeExceedLimit,
     UnauthorizedLicense,
     UnauthorizedPublisher,
     UnknownURL,
 )
-from welearn_datastack.modules.pdf_extractor import (
-    delete_accents,
-    delete_non_printable_character,
-    extract_txt_from_pdf_with_tika,
-    get_pdf_content,
-    remove_hyphens,
-    replace_ligatures,
-)
+from welearn_datastack.modules.pdf_extractor import get_pdf_content
 from welearn_datastack.plugins.interface import IPluginRESTCollector
 from welearn_datastack.utils_.http_client_utils import (
     get_http_code_from_exception,
     get_new_https_session,
 )
-from welearn_datastack.utils_.scraping_utils import remove_extra_whitespace
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request refactors the `open_alex.py` plugin by cleaning up unused imports and making a minor adjustment to HTTP client session handling. The changes streamline the codebase and slightly adjust HTTP request behavior.

Code cleanup and simplification:

* Removed unused imports such as `io`, `HEADERS`, `PDFFileSizeExceedLimit`, and several functions from `pdf_extractor` and `scraping_utils` to reduce clutter and improve maintainability. [[1]](diffhunk://#diff-4efd731fe340f23692fca448e882e3265bf579bcd88a00690ec72546f17e9338L1) [[2]](diffhunk://#diff-4efd731fe340f23692fca448e882e3265bf579bcd88a00690ec72546f17e9338L16) [[3]](diffhunk://#diff-4efd731fe340f23692fca448e882e3265bf579bcd88a00690ec72546f17e9338L34-L52)

HTTP client configuration:

* Updated the creation of the HTTP session in the `run` method to set `retry_total=2`, which may improve reliability for transient network errors.