### PR TITLE
Fix/okr author

### DIFF
--- a/tests/document_collector_hub/plugins_test/test_world_bank_okr.py
+++ b/tests/document_collector_hub/plugins_test/test_world_bank_okr.py
@@ -42,6 +42,14 @@ class TestWorldBankOpenKnowledgeRepository(TestCase):
             self.assertIn(a.name, ["Alice Good", "Bob Foo", "Alain De Loin Sur Perdu"])
             self.assertEqual(a.misc, "")
 
+    def test__process_authors_one_author(self):
+        input_lst = ["World Bank"]
+        ret = self.collector._process_authors(input_lst)
+        for a in ret:
+            self.assertIsInstance(a, AuthorDetails)
+            self.assertIn(a.name, ["World Bank"])
+            self.assertEqual(a.misc, "")
+
     def test__extract_licence(self):
         ret = self.collector._extract_licence(self.example_record)
         awaited = "https://creativecommons.org/licenses/by/3.0/igo/"

--- a/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
+++ b/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
@@ -71,9 +71,12 @@ class WorldBankOpenKnowledgeRepository(IPluginRESTCollector):
     def _process_authors(authors_str: list[str]) -> list[AuthorDetails]:
         ret = []
         for author in authors_str:
-            first_name = remove_extra_whitespace(author.split(",")[1])
-            last_name = remove_extra_whitespace(author.split(",")[0])
-            name = f"{first_name} {last_name}"
+            if "," in author:
+                first_name = remove_extra_whitespace(author.split(",")[1])
+                last_name = remove_extra_whitespace(author.split(",")[0])
+                name = f"{first_name} {last_name}"
+            else:
+                name = remove_extra_whitespace(author)
             ret.append(AuthorDetails(name=name, misc=""))
         return ret
 


### PR DESCRIPTION
This pull request improves the handling and testing of author name processing in the World Bank OKR plugin. The main changes include enhancing the `_process_authors` method to better handle single-author cases and adding a corresponding test to ensure correctness.

**Enhancements to author name processing:**

* Updated the `_process_authors` method in `world_bank_okr.py` to handle cases where an author string does not contain a comma, ensuring single-author names like "World Bank" are processed correctly.

**Testing improvements:**

* Added a new test `test__process_authors_one_author` in `test_world_bank_okr.py` to verify that single-author inputs are correctly processed by `_process_authors`.