### PR TITLE
fix: improve error handling in WorldBankOKRRecord model validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "welearn-datastack"
-version = "1.4.6"
+version = "1.4.7"
 description = "Data stack for WeLearn LPI projects. This pipeline can collect, vectorize and store data from various sources."
 authors = [
     { name = "Théo Nardin", email = "theo.nardin@learningplanetinstitute.org" },

--- a/tests/source_models/test_world_bank_okr.py
+++ b/tests/source_models/test_world_bank_okr.py
@@ -67,7 +67,7 @@ class TestWorldBankOKRModel(unittest.TestCase):
                 XMLExtractor(self.example_content.replace("fileGrp", "toto"))
             )
 
-    def test_model_with_empty_filegrp(self):
+    def test_model_without_flocat(self):
         with self.assertRaises(ValidationError):
             WorldBankOKRRecord.model_validate(
                 XMLExtractor(self.example_content.replace("FLocat", "toto"))

--- a/tests/source_models/test_world_bank_okr.py
+++ b/tests/source_models/test_world_bank_okr.py
@@ -1,6 +1,8 @@
 import unittest
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from welearn_datastack.data.source_models.world_bank_okr import WorldBankOKRRecord
 from welearn_datastack.modules.xml_extractor import XMLExtractor
 
@@ -58,3 +60,33 @@ class TestWorldBankOKRModel(unittest.TestCase):
             model.fileGrp[1].flocat.href,
             "https://openknowledge.worldbank.org/bitstreams/e189cde3-ebf4-5360-a248-2ea3e05fa5d6/download",
         )
+
+    def test_model_without_filegrp(self):
+        with self.assertRaises(ValidationError):
+            WorldBankOKRRecord.model_validate(
+                XMLExtractor(self.example_content.replace("fileGrp", "toto"))
+            )
+
+    def test_model_with_empty_filegrp(self):
+        with self.assertRaises(ValidationError):
+            WorldBankOKRRecord.model_validate(
+                XMLExtractor(self.example_content.replace("FLocat", "toto"))
+            )
+
+    def test_model_with_empty_identifiers(self):
+        with self.assertRaises(ValidationError):
+            WorldBankOKRRecord.model_validate(
+                XMLExtractor(self.example_content.replace("identifier", "toto"))
+            )
+
+    def test_model_without_title(self):
+        with self.assertRaises(ValidationError):
+            WorldBankOKRRecord.model_validate(
+                XMLExtractor(self.example_content.replace("title", "toto"))
+            )
+
+    def test_model_without_abstract(self):
+        with self.assertRaises(ValidationError):
+            WorldBankOKRRecord.model_validate(
+                XMLExtractor(self.example_content.replace("abstract", "toto"))
+            )

--- a/welearn_datastack/data/source_models/world_bank_okr.py
+++ b/welearn_datastack/data/source_models/world_bank_okr.py
@@ -60,11 +60,17 @@ class WorldBankOKRRecord(BaseModel):
                     k.lower().replace("xlink:", ""): v
                     for k, v in flocat_xml[0].attributes.items()
                 }
-                f_ret["flocat"] = flocat_ret
-            except IndexError:
+            except IndexError as e:
                 raise ValueError(
-                    "There is no flocat in this document, so can't find address"
+                    "Missing <FLocat> tag in <file>; cannot determine file address"
+                ) from e
+
+            if not flocat_ret.get("href"):
+                raise ValueError(
+                    "Missing xlink:href on <FLocat>; cannot determine file address"
                 )
+
+            f_ret["flocat"] = flocat_ret
             ret.append(f_ret)
         return ret
 
@@ -89,8 +95,11 @@ class WorldBankOKRRecord(BaseModel):
             uri = value.extract_content_attribute_filter(
                 tag="mods:identifier", attribute_name="type", attribute_value="uri"
             )[0].content
-        except IndexError:
-            raise ValueError("No URI in this document")
+        except IndexError as e:
+            raise ValueError('Missing <mods:identifier type="uri"> in document') from e
+
+        if not uri:
+            raise ValueError('Empty <mods:identifier type="uri"> in document')
         doi_items = value.extract_content_attribute_filter(
             tag="mods:identifier", attribute_name="type", attribute_value="doi"
         )

--- a/welearn_datastack/data/source_models/world_bank_okr.py
+++ b/welearn_datastack/data/source_models/world_bank_okr.py
@@ -2,7 +2,6 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, model_validator
 
-from welearn_datastack.exceptions import NoDescriptionFoundError, NoTitle
 from welearn_datastack.modules.xml_extractor import XMLExtractor
 
 

--- a/welearn_datastack/data/source_models/world_bank_okr.py
+++ b/welearn_datastack/data/source_models/world_bank_okr.py
@@ -48,15 +48,23 @@ class WorldBankOKRRecord(BaseModel):
     @classmethod
     def _extract_file_grp(cls, value: XMLExtractor) -> list[dict]:
         ret = []
-        file_grp = value.extract_content(tag="fileGrp")[0].content
+        try:
+            file_grp = value.extract_content(tag="fileGrp")[0].content
+        except IndexError:
+            raise ValueError("There is no fileGrp in this document")
         for f in XMLExtractor(file_grp).extract_content(tag="file"):
             f_ret = {k.lower(): v for k, v in f.attributes.items()}
             flocat_xml = XMLExtractor(f.content).extract_content(tag="FLocat")
-            flocat_ret = {
-                k.lower().replace("xlink:", ""): v
-                for k, v in flocat_xml[0].attributes.items()
-            }
-            f_ret["flocat"] = flocat_ret
+            try:
+                flocat_ret = {
+                    k.lower().replace("xlink:", ""): v
+                    for k, v in flocat_xml[0].attributes.items()
+                }
+                f_ret["flocat"] = flocat_ret
+            except IndexError:
+                raise ValueError(
+                    "There is no flocat in this document, so can't find address"
+                )
             ret.append(f_ret)
         return ret
 
@@ -77,9 +85,12 @@ class WorldBankOKRRecord(BaseModel):
 
     @classmethod
     def _extract_identifiers(cls, value: XMLExtractor) -> dict[str, str | None]:
-        uri = value.extract_content_attribute_filter(
-            tag="mods:identifier", attribute_name="type", attribute_value="uri"
-        )[0].content
+        try:
+            uri = value.extract_content_attribute_filter(
+                tag="mods:identifier", attribute_name="type", attribute_value="uri"
+            )[0].content
+        except IndexError:
+            raise ValueError("No URI in this document")
         doi_items = value.extract_content_attribute_filter(
             tag="mods:identifier", attribute_name="type", attribute_value="doi"
         )
@@ -95,7 +106,7 @@ class WorldBankOKRRecord(BaseModel):
             try:
                 title = value.extract_content(tag="mods:title")[0].content
             except IndexError:
-                raise NoTitle
+                raise ValueError("No title in this document")
 
             _authors = [a.content for a in value.extract_content(tag="mods:namePart")]
             _subjects = [s.content for s in value.extract_content(tag="mods:topic")]
@@ -109,7 +120,7 @@ class WorldBankOKRRecord(BaseModel):
             try:
                 _abstract = value.extract_content(tag="mods:abstract")[0].content
             except IndexError:
-                raise NoDescriptionFoundError
+                raise ValueError("No abstract in this document")
 
             ret = {
                 "authors": _authors,

--- a/welearn_datastack/data/source_models/world_bank_okr.py
+++ b/welearn_datastack/data/source_models/world_bank_okr.py
@@ -50,8 +50,8 @@ class WorldBankOKRRecord(BaseModel):
         ret = []
         try:
             file_grp = value.extract_content(tag="fileGrp")[0].content
-        except IndexError:
-            raise ValueError("There is no fileGrp in this document")
+        except IndexError as e:
+            raise ValueError("Missing <fileGrp> tag in document") from e
         for f in XMLExtractor(file_grp).extract_content(tag="file"):
             f_ret = {k.lower(): v for k, v in f.attributes.items()}
             flocat_xml = XMLExtractor(f.content).extract_content(tag="FLocat")

--- a/welearn_datastack/data/source_models/world_bank_okr.py
+++ b/welearn_datastack/data/source_models/world_bank_okr.py
@@ -114,8 +114,8 @@ class WorldBankOKRRecord(BaseModel):
 
             try:
                 title = value.extract_content(tag="mods:title")[0].content
-            except IndexError:
-                raise ValueError("No title in this document")
+            except IndexError as e:
+                raise ValueError("No title in this document") from e
 
             _authors = [a.content for a in value.extract_content(tag="mods:namePart")]
             _subjects = [s.content for s in value.extract_content(tag="mods:topic")]
@@ -128,8 +128,8 @@ class WorldBankOKRRecord(BaseModel):
 
             try:
                 _abstract = value.extract_content(tag="mods:abstract")[0].content
-            except IndexError:
-                raise ValueError("No abstract in this document")
+            except IndexError as e:
+                raise ValueError("No abstract in this document") from e
 
             ret = {
                 "authors": _authors,


### PR DESCRIPTION
This pull request improves the robustness and test coverage of the `WorldBankOKRRecord` model by adding validation for missing or malformed XML fields and expanding the test suite to cover these scenarios. The main changes are grouped into enhanced validation logic and expanded test coverage.

**Enhanced validation logic:**

* Updated `_extract_file_grp` in `world_bank_okr.py` to raise a `ValueError` with a descriptive message if the `fileGrp` or `FLocat` tags are missing from the XML input, improving error reporting for malformed documents.
* Modified `_extract_identifiers` to raise a `ValueError` when no URI identifier is found, ensuring required fields are present.
* Changed error handling in `support_xml_extractor` to raise a `ValueError` with clear messages if `title` or `abstract` tags are missing, replacing custom exceptions for consistency and clarity. [[1]](diffhunk://#diff-9ccf0a695fd5ed5689fe8a1de41c5c017977f2bcb3edbe17ed7a6a500842708dL98-R109) [[2]](diffhunk://#diff-9ccf0a695fd5ed5689fe8a1de41c5c017977f2bcb3edbe17ed7a6a500842708dL112-R123)

**Expanded test coverage:**

* Added new tests in `test_world_bank_okr.py` to verify that the model correctly raises `ValidationError` when required XML fields (`fileGrp`, `FLocat`, `identifier`, `title`, `abstract`) are missing or empty, ensuring the validation logic works as intended.
* Imported `ValidationError` from `pydantic` in the test file to support the new test cases.