### PR TITLE
fix: update world bank document handling to use description as full c…

### DIFF
--- a/tests/document_collector_hub/plugins_test/test_world_bank_okr.py
+++ b/tests/document_collector_hub/plugins_test/test_world_bank_okr.py
@@ -175,11 +175,17 @@ class TestWorldBankOpenKnowledgeRepository(TestCase):
         ret = self.collector._update_welearn_document(wrapper)
 
         self.assertEqual(ret.title, self.example_record.title)
-        self.assertEqual(ret.full_content, full_content)
+        # self.assertEqual(ret.full_content, full_content) # We use description as full content
+        self.assertEqual(
+            ret.full_content, ret.description
+        )  # We use description as full content
+
         self.assertTrue(
             ret.description.startswith("International river basins will likely")
         )
-        self.assertTrue(ret.details["content_from_txt"])
+        self.assertFalse(ret.details["content_from_txt"])
+        # self.assertTrue(ret.details["content_from_txt"])
+        self.assertTrue(ret.details["content_from_description"])
         self.assertFalse(ret.details["content_from_pdf"])
 
     @patch.object(WorldBankOpenKnowledgeRepository, "_extract_licence")

--- a/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
+++ b/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
@@ -216,9 +216,7 @@ class WorldBankOpenKnowledgeRepository(IPluginRESTCollector):
         doc.title = wrapper.raw_data.title
         doc.doi = clean_doi(wrapper.raw_data.identifiers.doi)
         doc.description = wrapper.raw_data.abstract
-        full_content = (
-            doc.description
-        )  # We switch on abstract for these document since world bank don't let us scrape their PDF
+        full_content = doc.description  # Use description (abstract) as full content; PDF/TXT scraping is not permitted for this source.
         doc.full_content = full_content
         details = self._build_details(wrapper.raw_data)
         details.update(

--- a/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
+++ b/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
@@ -216,13 +216,16 @@ class WorldBankOpenKnowledgeRepository(IPluginRESTCollector):
         doc.title = wrapper.raw_data.title
         doc.doi = clean_doi(wrapper.raw_data.identifiers.doi)
         doc.description = wrapper.raw_data.abstract
-        full_content, is_txt = self._extract_full_content(wrapper.raw_data)
+        full_content = (
+            doc.description
+        )  # We switch on abstract for these document since world bank don't let us scrape their PDF
         doc.full_content = full_content
         details = self._build_details(wrapper.raw_data)
         details.update(
             {
-                "content_from_pdf": not is_txt,
-                "content_from_txt": is_txt,
+                "content_from_pdf": False,
+                "content_from_txt": False,
+                "content_from_description": True,
                 "licence": licence,
             }
         )
@@ -240,6 +243,7 @@ class WorldBankOpenKnowledgeRepository(IPluginRESTCollector):
                     document=doc,
                     raw_data=self._retrieve_record_from_oai(doc.external_id, client),
                 )
+
             except requests.exceptions.RequestException as e:
                 msg = f"Error while retrieving World bank OKR document ({doc.url}) document from this url {self.api_base_url}/?verb=GetRecord&identifier={doc.external_id}: {e}"
                 logger.error(msg)

--- a/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
+++ b/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
@@ -216,7 +216,9 @@ class WorldBankOpenKnowledgeRepository(IPluginRESTCollector):
         doc.title = wrapper.raw_data.title
         doc.doi = clean_doi(wrapper.raw_data.identifiers.doi)
         doc.description = wrapper.raw_data.abstract
-        full_content = doc.description  # Use description (abstract) as full content; PDF/TXT scraping is not permitted for this source.
+        full_content = (
+            doc.description
+        )  # Use description (abstract) as full content; PDF/TXT scraping is not permitted for this source.
         doc.full_content = full_content
         details = self._build_details(wrapper.raw_data)
         details.update(


### PR DESCRIPTION
This pull request updates how full content is handled for World Bank Open Knowledge Repository documents. Instead of attempting to extract and use the full text or PDF content (which is restricted), the system now uses the document's description (abstract) as the full content. Additionally, the metadata flags in the details are updated to accurately reflect the new content source.

**Content extraction logic changes:**

* The `_update_welearn_document` method in `world_bank_okr.py` now sets `doc.full_content` to the document's description instead of extracted text or PDF content, since scraping full content is not permitted.
* The `details` dictionary is updated to set `content_from_pdf` and `content_from_txt` to `False`, and introduces `content_from_description` as `True` to reflect the actual source of content.

**Test updates:**

* The test `test__update_welearn_document` is updated to check that `ret.full_content` matches the description, and to verify the new details flags (`content_from_description` is `True`, others are `False`).

**Minor code cleanup:**

* An extra line break is added after a `WrapperRetrieveDocument` instantiation for readability.