### PR TITLE
Bugfix due to Sentence Transformers removal

### DIFF
--- a/tests/keywords_extractor/test_keywords_extractor.py
+++ b/tests/keywords_extractor/test_keywords_extractor.py
@@ -69,5 +69,10 @@ class TestKeywordsExtractor(unittest.TestCase):
         # Assertions
         mock_generate_ml_models_path.assert_called_once()
         mock_load_embedding_model.assert_called_once_with("mock_path")
+        mock_pipeline.assert_called_once_with(
+            "feature-extraction",
+            model="mock_embedding_model",
+            tokenizer="mock_tokenizer",
+        )
         mock_kw_model.extract_keywords.assert_called_once()
         self.assertEqual(keywords, ["keyword1"])

--- a/welearn_datastack/modules/embedding_model_helpers.py
+++ b/welearn_datastack/modules/embedding_model_helpers.py
@@ -54,8 +54,13 @@ def _compute_embeddings(model, tokenizer, inputs: list[str]) -> np.ndarray:
         model_output = model(**tokenized_inputs)
         # Perform pooling. granite-embedding-107m-multilingual uses CLS Pooling
         embeddings = model_output[0][:, 0]
+        # NumPy conversion does not support bfloat16 tensors.
         embeddings = (
-            torch.nn.functional.normalize(embeddings, dim=1).detach().cpu().numpy()
+            torch.nn.functional.normalize(embeddings, dim=1)
+            .to(torch.float32)
+            .detach()
+            .cpu()
+            .numpy()
         )
     return embeddings
 

--- a/welearn_datastack/modules/keywords_extractor.py
+++ b/welearn_datastack/modules/keywords_extractor.py
@@ -32,11 +32,12 @@ def extract_keywords(
         model_name=embedding_model_name_from_db,
         extension="",
     )
-    embedding_model, _ = load_embedding_model(ml_path.as_posix())
+    embedding_model, tokenizer = load_embedding_model(ml_path.as_posix())
     kw_model = KeyBERT(
         model=pipeline(
             "feature-extraction",
             model=embedding_model,
+            tokenizer=tokenizer,
         )
     )
 


### PR DESCRIPTION
This pull request improves the handling of embedding models and their tokenizers, ensuring better compatibility and correctness when extracting keywords using the KeyBERT-based pipeline. The main changes address proper passing of both the model and tokenizer, and fix an issue with tensor type conversion for embeddings.

**Embedding model and tokenizer handling:**

* Updated `extract_keywords` to correctly unpack both `embedding_model` and `tokenizer` from `load_embedding_model`, and to pass both to the `pipeline` used by `KeyBERT`.

* Enhanced the test for `extract_keywords` to assert that the pipeline is called with both the model and tokenizer.

**Embedding computation fixes:**

* Modified `_compute_embeddings` to explicitly cast embeddings to `torch.float32` before converting to NumPy, preventing issues with unsupported tensor types like `bfloat16`.