### PR TITLE
Fix: handle WeLearnDatabaseException in document retrieval

### DIFF
--- a/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
+++ b/welearn_datastack/plugins/rest_requesters/world_bank_okr.py
@@ -10,6 +10,7 @@ import pydantic
 import requests
 from requests import Session
 from welearn_database.data.models import WeLearnDocument
+from welearn_database.exceptions import WeLearnDatabaseException
 
 from welearn_datastack.constants import AUTHORIZED_LICENSES, HEADERS
 from welearn_datastack.data.db_wrapper import WrapperRawData, WrapperRetrieveDocument
@@ -303,6 +304,16 @@ class WorldBankOpenKnowledgeRepository(IPluginRESTCollector):
                 continue
             except FileTypeUnsupported as e:
                 msg = f"FileTypeUnsupported exception for document {ret_doc.document.url}: {e}"
+                logger.error(msg)
+                ret.append(
+                    WrapperRetrieveDocument(
+                        document=ret_doc.document,
+                        error_info=msg,
+                    )
+                )
+                continue
+            except WeLearnDatabaseException as e:
+                msg = f"Database exception for document {ret_doc.document.url}: {e}"
                 logger.error(msg)
                 ret.append(
                     WrapperRetrieveDocument(


### PR DESCRIPTION
This pull request adds improved error handling for database exceptions in the `world_bank_okr.py` REST requester plugin. Now, if a `WeLearnDatabaseException` is raised during document processing, it is caught and logged, and the error information is attached to the returned result for that document.

**Error Handling Improvements:**

* Added import for `WeLearnDatabaseException` to handle database-specific errors in `world_bank_okr.py`.
* Updated the `run` method to catch `WeLearnDatabaseException`, log the error with details, and append a `WrapperRetrieveDocument` containing the error info for the affected document.