### PR TITLE
Fix: refactor total size calculation in document retrieval

### DIFF
--- a/welearn_datastack/modules/retrieve_data_from_database.py
+++ b/welearn_datastack/modules/retrieve_data_from_database.py
@@ -252,7 +252,7 @@ def retrieve_documents_ids_according_process_title(
 
 
 def compute_total_size(
-    db_data: list[tuple[UUID, str, int]] | list[tuple[UUID, str, int, int]]
+    db_data: list[tuple[UUID, str, int]] | list[tuple[UUID, str, int, int]],
 ) -> int:
     ret = 0
     for x in db_data:

--- a/welearn_datastack/modules/retrieve_data_from_database.py
+++ b/welearn_datastack/modules/retrieve_data_from_database.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Collection, Dict, List, Type, TypedDict
+from typing import Collection, Dict, List, Literal, Type, TypedDict
 from uuid import UUID
 
 from sqlalchemy import Column, desc
@@ -209,7 +209,7 @@ def retrieve_documents_ids_according_process_title(
             logger.info(
                 "Filtering on document size, every values are in bytes an concern the full_content field"
             )
-            total_size = sum([x[2] for x in db_data])  # type: ignore
+            total_size = compute_total_size(db_data)
         elif weighed_scope == WeighedScope.SLICE:
             # Sum of body and embedding
             logger.info(
@@ -249,6 +249,16 @@ def retrieve_documents_ids_according_process_title(
     logger.info("Found %s results", len(db_data))
 
     return [str(x[0]) for x in db_data]
+
+
+def compute_total_size(
+    db_data: list[tuple[UUID, str, int]] | list[tuple[UUID, str, int, int]]
+) -> int:
+    ret = 0
+    for x in db_data:
+        if x:
+            ret += x[2]
+    return ret
 
 
 def retrieve_random_documents_ids_according_process_title(


### PR DESCRIPTION
This pull request refactors how the total document size is computed in the `retrieve_documents_ids_according_process_title` function and introduces a new helper function to improve code clarity and maintainability. The main change is extracting the summing logic into a dedicated function, which makes the code easier to read and test.

**Refactoring for clarity and maintainability:**

* Extracted the logic for summing document sizes into a new helper function `compute_total_size`, and updated `retrieve_documents_ids_according_process_title` to use this helper instead of an inline sum. [[1]](diffhunk://#diff-cb9bc2d5a5e9b70f7253b362dd353760acebff95654d57bcf788e0912b1a3e5bL212-R212) [[2]](diffhunk://#diff-cb9bc2d5a5e9b70f7253b362dd353760acebff95654d57bcf788e0912b1a3e5bR254-R263)

**Type hint improvements:**

* Updated the type hints in the import section to include `Literal`, reflecting broader or future usage of type hints.