### PR TITLE
Feature/urlc sitemap

### DIFF
--- a/k8s/welearn-datastack/templates/urlcollectors/cron-workflow.yaml
+++ b/k8s/welearn-datastack/templates/urlcollectors/cron-workflow.yaml
@@ -370,5 +370,16 @@ spec:
                 name: {{ .name }}
                 template: collect-world-bank-okr
 
+            - name: notre-environnement
+              templateRef:
+                name: {{ .name }}
+                template: collect-sitemap
+              arguments:
+                parameters:
+                  - name: sitemap_url
+                    value: https://www.notre-environnement.gouv.fr/sitemap.xml
+                  - name: corpus_name
+                    value: notre-environnement
+
 {{- end }}
 {{- end }}

--- a/k8s/welearn-datastack/templates/urlcollectors/workflow-template.yaml
+++ b/k8s/welearn-datastack/templates/urlcollectors/workflow-template.yaml
@@ -121,6 +121,7 @@ spec:
           volumeAttributes:
             secretName: {{ $.Values.common.azureShare.secret.name }}
             shareName: {{ $.Values.common.azureShare.name }}
+
     - name: collect-wikipedia
       synchronization:
         semaphores:
@@ -460,7 +461,6 @@ spec:
             secretName: {{ $.Values.common.azureShare.secret.name }}
             shareName: {{ $.Values.common.azureShare.name }}
 
-
     - name: collect-world-bank-okr
       synchronization:
         semaphores:
@@ -478,6 +478,50 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ .name }}
+        volumeMounts:
+        - name: secrets
+          mountPath: "/secrets"
+          readOnly: true
+        - name: azure-share
+          mountPath: {{ $.Values.common.azureShare.mountPath }}
+      volumes:
+      - name: secrets
+        secret:
+          secretName: {{ .name }}
+      - name: azure-share
+        csi:
+          driver: file.csi.azure.com
+          readOnly: true
+          volumeAttributes:
+            secretName: {{ $.Values.common.azureShare.secret.name }}
+            shareName: {{ $.Values.common.azureShare.name }}
+
+    - name: collect-sitemap
+      synchronization:
+        semaphores:
+        - configMapKeyRef:
+            name: {{ .collectorSemaphore.configmapName }}
+            key: {{ .collectorSemaphore.standard.keyName }}
+      inputs:
+        parameters:
+        - name: sitemap_url
+        - name: corpus_name
+      container:
+      {{- with $.Values.image }}
+        image: {{ include "common.pods.image" (dict "root" $ "image" (dict "repository" .repository "path" .path "tag" .tag))}}
+      {{- end }}
+        args:
+          - python
+          - "-m"
+          - welearn_datastack.nodes_workflow.URLCollectors.node_sitemap_collect
+        envFrom:
+          - configMapRef:
+              name: {{ .name }}
+        env:
+          - name: SITEMAP_URL
+            value: {{ print "{{inputs.parameters.sitemap_url}}" | quote }}
+          - name: CORPUS_NAME
+            value: {{ print "{{inputs.parameters.corpus_name}}" | quote }}
         volumeMounts:
         - name: secrets
           mountPath: "/secrets"

--- a/tests/url_collector/test_sitemap_collector.py
+++ b/tests/url_collector/test_sitemap_collector.py
@@ -91,7 +91,7 @@ class TestSitemapURLCollector(TestCase):
 
     def test__exxtract_url_from_sitemap_index(self):
         awaited_ret = [
-            "httpss://www.example.org/post-sitemap.xml",
+            "https://www.example.org/post-sitemap.xml",
             "https://www.example.org/post-sitemap2.xml",
             "https://www.example.org/post-sitemap3.xml",
             "https://www.example.org/page-sitemap.xml",
@@ -144,10 +144,10 @@ class TestSitemapURLCollector(TestCase):
         sitemap_resp.raise_for_status.assert_called_once()
         pages_resp.raise_for_status.assert_called_once()
 
-        mock_is_index.assert_called_once_with(sitemap_resp.content)
+        mock_is_index.assert_called_once_with(sitemap_resp.content.decode("utf-8"))
 
         self.assertEqual(mock_extract_urls.call_count, 1)
-        mock_extract_urls.assert_called_once_with(pages_resp.content)
+        mock_extract_urls.assert_called_once_with(pages_resp.content.decode("utf-8"))
 
         mock_extract_datastore.assert_called_once_with(
             urls=["https://example.com/page1"], corpus=self.corpus
@@ -166,12 +166,11 @@ class TestSitemapURLCollector(TestCase):
 
         root_resp = MagicMock(content=b"<sitemapindex></sitemapindex>")
         sub_resp = MagicMock(content=b"<urlset>sub</urlset>")
-        pages_resp = MagicMock(content=b"<urlset>pages</urlset>")
 
-        for resp in (root_resp, sub_resp, pages_resp):
+        for resp in (root_resp, sub_resp):
             resp.raise_for_status = MagicMock()
 
-        mock_session.get.side_effect = [root_resp, sub_resp, pages_resp]
+        mock_session.get.side_effect = [root_resp, sub_resp]
 
         with (
             patch.object(self.collector, "_is_sitemap_index", return_value=True),
@@ -182,9 +181,6 @@ class TestSitemapURLCollector(TestCase):
                     [
                         "https://example.com/sub-sitemap.xml"
                     ],  # extraction depuis root (sous-sitemaps)
-                    [
-                        "https://example.com/sub-sitemap.xml"
-                    ],  # extraction depuis sub_resp -> sitemaps_urls
                     [
                         "https://example.com/page1",
                         "https://example.com/page2",
@@ -197,18 +193,17 @@ class TestSitemapURLCollector(TestCase):
 
             result = self.collector.collect()
 
-        self.assertEqual(mock_session.get.call_count, 3)
+        self.assertEqual(mock_session.get.call_count, 2)
         mock_session.get.assert_has_calls(
             [
                 call("https://example.org/sitemap.xml"),
                 call("https://example.com/sub-sitemap.xml"),
-                call("https://example.com/sub-sitemap.xml"),
             ]
         )
-        for resp in (root_resp, sub_resp, pages_resp):
+        for resp in (root_resp, sub_resp):
             resp.raise_for_status.assert_called_once()
 
-        self.assertEqual(mock_extract_urls.call_count, 3)
+        self.assertEqual(mock_extract_urls.call_count, 2)
         mock_extract_datastore.assert_called_once_with(
             urls=["https://example.com/page1", "https://example.com/page2"],
             corpus=self.corpus,

--- a/tests/url_collector/test_sitemap_collector.py
+++ b/tests/url_collector/test_sitemap_collector.py
@@ -1,0 +1,261 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+
+from welearn_database.data.models import Corpus, WeLearnDocument
+
+from welearn_datastack.collectors.sitemap_collector import SiteMapURLCollector
+
+
+class TestSitemapURLCollector(TestCase):
+    def setUp(self):
+        self.sitemap_index_content = """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="//www.example.org/wp-content/plugins/wordpress-seo/css/main-sitemap.xsl"?>
+            <sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+                <sitemap>
+                    <loc>https://www.example.org/post-sitemap.xml</loc>
+                    <lastmod>2026-07-15T08:48:24+00:00</lastmod>
+                </sitemap>
+                <sitemap>
+                    <loc>https://www.example.org/post-sitemap2.xml</loc>
+                    <lastmod>2025-01-16T10:33:52+00:00</lastmod>
+                </sitemap>
+                <sitemap>
+                    <loc>https://www.example.org/post-sitemap3.xml</loc>
+                    <lastmod>2026-07-15T08:48:24+00:00</lastmod>
+                </sitemap>
+                <sitemap>
+                    <loc>https://www.example.org/page-sitemap.xml</loc>
+                    <lastmod>2026-07-08T13:24:10+00:00</lastmod>
+                </sitemap>
+                <sitemap>
+                    <loc>https://www.example.org/formation-sitemap.xml</loc>
+                    <lastmod>2026-07-09T15:20:48+00:00</lastmod>
+                </sitemap>
+            </sitemapindex>
+        """
+
+        self.sitemap_content = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+               <url>
+                  <loc>https://www.example.com/</loc>
+                  <lastmod>2005-01-01</lastmod>
+                  <changefreq>monthly</changefreq>
+                  <priority>0.8</priority>
+               </url>
+            
+               <url>
+                  <loc>https://www.example.com/catalog?item=12&amp;desc=vacation_hawaii</loc>
+                  <changefreq>weekly</changefreq>
+               </url>
+            
+               <url>
+                  <loc>https://www.example.com/catalog?item=73&amp;desc=vacation_new_zealand</loc>
+                  <lastmod>2004-12-23</lastmod>
+                  <changefreq>weekly</changefreq>
+               </url>
+            
+               <url>
+                  <loc>https://www.example.com/catalog?item=74&amp;desc=vacation_newfoundland</loc>
+                  <lastmod>2004-12-23T18:00:15+00:00</lastmod>
+                  <priority>0.3</priority>
+               </url>
+            
+               <url>
+                  <loc>https://www.example.com/catalog?item=83&amp;desc=vacation_usa</loc>
+                  <lastmod>2004-11-23</lastmod>
+               </url>
+            </urlset>
+        """
+        self.corpus = Corpus(source_name="example", main_url="example.org")
+        self.collector = SiteMapURLCollector(
+            sitemap_url="https://example.org/sitemap.xml", corpus=self.corpus
+        )
+
+    def test__check_sitemap_index_is_index(self) -> None:
+        self.assertTrue(self.collector._is_sitemap_index(self.sitemap_index_content))
+
+    def test__check_sitemap_index_is_not_index(self) -> None:
+        self.assertFalse(self.collector._is_sitemap_index(self.sitemap_content))
+
+    def test__extract_url_from_regular_sitemap(self):
+        awaited_ret = [
+            "https://www.example.com/",
+            "https://www.example.com/catalog?item=12&amp;desc=vacation_hawaii",
+            "https://www.example.com/catalog?item=73&amp;desc=vacation_new_zealand",
+            "https://www.example.com/catalog?item=74&amp;desc=vacation_newfoundland",
+            "https://www.example.com/catalog?item=83&amp;desc=vacation_usa",
+        ]
+        urls = self.collector._extract_urls(self.sitemap_content)
+        self.assertListEqual(urls, awaited_ret)
+
+    def test__exxtract_url_from_sitemap_index(self):
+        awaited_ret = [
+            "httpss://www.example.org/post-sitemap.xml",
+            "https://www.example.org/post-sitemap2.xml",
+            "https://www.example.org/post-sitemap3.xml",
+            "https://www.example.org/page-sitemap.xml",
+            "https://www.example.org/formation-sitemap.xml",
+        ]
+        urls = self.collector._extract_urls(self.sitemap_index_content)
+        self.assertListEqual(urls, awaited_ret)
+
+    @patch(
+        "welearn_datastack.collectors.sitemap_collector.extracted_url_to_url_datastore"
+    )
+    @patch("welearn_datastack.collectors.sitemap_collector.get_new_https_session")
+    def test_collect_simple_sitemap_not_index(
+        self, mock_get_session, mock_extract_datastore
+    ):
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        sitemap_resp = MagicMock()
+        sitemap_resp.content = b"<urlset></urlset>"
+        sitemap_resp.raise_for_status = MagicMock()
+
+        pages_resp = MagicMock()
+        pages_resp.content = b"<urlset><url>...</url></urlset>"
+        pages_resp.raise_for_status = MagicMock()
+
+        # Premier appel .get() -> sitemap racine, deuxième -> pages
+        mock_session.get.side_effect = [sitemap_resp, pages_resp]
+
+        with (
+            patch.object(
+                self.collector, "_is_sitemap_index", return_value=False
+            ) as mock_is_index,
+            patch.object(
+                self.collector,
+                "_extract_urls",
+                return_value=["https://example.com/page1"],
+            ) as mock_extract_urls,
+        ):
+            expected_docs = [MagicMock(spec=WeLearnDocument)]
+            mock_extract_datastore.return_value = expected_docs
+
+            result = self.collector.collect()
+
+        mock_get_session.assert_called_once()
+        self.assertEqual(mock_session.get.call_count, 2)
+        mock_session.get.assert_any_call("https://example.org/sitemap.xml")
+        mock_session.get.assert_any_call("https://example.org/sitemap.xml")
+
+        sitemap_resp.raise_for_status.assert_called_once()
+        pages_resp.raise_for_status.assert_called_once()
+
+        mock_is_index.assert_called_once_with(sitemap_resp.content)
+
+        self.assertEqual(mock_extract_urls.call_count, 1)
+        mock_extract_urls.assert_called_once_with(pages_resp.content)
+
+        mock_extract_datastore.assert_called_once_with(
+            urls=["https://example.com/page1"], corpus=self.corpus
+        )
+        self.assertEqual(result, expected_docs)
+
+    @patch(
+        "welearn_datastack.collectors.sitemap_collector.extracted_url_to_url_datastore"
+    )
+    @patch("welearn_datastack.collectors.sitemap_collector.get_new_https_session")
+    def test_collect_sitemap_index_with_subsitemaps(
+        self, mock_get_session, mock_extract_datastore
+    ):
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        root_resp = MagicMock(content=b"<sitemapindex></sitemapindex>")
+        sub_resp = MagicMock(content=b"<urlset>sub</urlset>")
+        pages_resp = MagicMock(content=b"<urlset>pages</urlset>")
+
+        for resp in (root_resp, sub_resp, pages_resp):
+            resp.raise_for_status = MagicMock()
+
+        mock_session.get.side_effect = [root_resp, sub_resp, pages_resp]
+
+        with (
+            patch.object(self.collector, "_is_sitemap_index", return_value=True),
+            patch.object(
+                self.collector,
+                "_extract_urls",
+                side_effect=[
+                    [
+                        "https://example.com/sub-sitemap.xml"
+                    ],  # extraction depuis root (sous-sitemaps)
+                    [
+                        "https://example.com/sub-sitemap.xml"
+                    ],  # extraction depuis sub_resp -> sitemaps_urls
+                    [
+                        "https://example.com/page1",
+                        "https://example.com/page2",
+                    ],  # extraction pages
+                ],
+            ) as mock_extract_urls,
+        ):
+            expected_docs = ["doc1", "doc2"]
+            mock_extract_datastore.return_value = expected_docs
+
+            result = self.collector.collect()
+
+        self.assertEqual(mock_session.get.call_count, 3)
+        mock_session.get.assert_has_calls(
+            [
+                call("https://example.org/sitemap.xml"),
+                call("https://example.com/sub-sitemap.xml"),
+                call("https://example.com/sub-sitemap.xml"),
+            ]
+        )
+        for resp in (root_resp, sub_resp, pages_resp):
+            resp.raise_for_status.assert_called_once()
+
+        self.assertEqual(mock_extract_urls.call_count, 3)
+        mock_extract_datastore.assert_called_once_with(
+            urls=["https://example.com/page1", "https://example.com/page2"],
+            corpus=self.corpus,
+        )
+        self.assertEqual(result, expected_docs)
+
+    @patch("welearn_datastack.collectors.sitemap_collector.get_new_https_session")
+    def test_collect_raises_when_root_sitemap_http_error(self, mock_get_session):
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        sitemap_resp = MagicMock()
+        sitemap_resp.raise_for_status.side_effect = Exception("HTTP 500")
+        mock_session.get.return_value = sitemap_resp
+
+        with self.assertRaises(Exception):
+            self.collector.collect()
+
+        mock_session.get.assert_called_once_with("https://example.org/sitemap.xml")
+
+    @patch(
+        "welearn_datastack.collectors.sitemap_collector.extracted_url_to_url_datastore"
+    )
+    @patch("welearn_datastack.collectors.sitemap_collector.get_new_https_session")
+    def test_collect_raises_when_subsitemap_http_error(
+        self, mock_get_session, mock_extract_datastore
+    ):
+        mock_session = MagicMock()
+        mock_get_session.return_value = mock_session
+
+        root_resp = MagicMock(content=b"<sitemapindex></sitemapindex>")
+        root_resp.raise_for_status = MagicMock()
+
+        sub_resp = MagicMock()
+        sub_resp.raise_for_status.side_effect = Exception("HTTP 404")
+
+        mock_session.get.side_effect = [root_resp, sub_resp]
+
+        with (
+            patch.object(self.collector, "_is_sitemap_index", return_value=True),
+            patch.object(
+                self.collector,
+                "_extract_urls",
+                return_value=["https://example.com/broken-sub.xml"],
+            ),
+        ):
+            with self.assertRaises(Exception):
+                self.collector.collect()
+
+        mock_extract_datastore.assert_not_called()

--- a/welearn_datastack/collectors/sitemap_collector.py
+++ b/welearn_datastack/collectors/sitemap_collector.py
@@ -58,7 +58,7 @@ class SiteMapURLCollector(URLCollector):
 
         sitemap_resp = http_client.get(self.sitemap_url)
         sitemap_resp.raise_for_status()
-        sitemap_content = sitemap_resp.content
+        sitemap_content = sitemap_resp.content.decode("utf-8")
 
         is_index = self._is_sitemap_index(sitemap_content)
         logger.info("Sitemap is index ? : %s", is_index)
@@ -66,11 +66,7 @@ class SiteMapURLCollector(URLCollector):
         sitemaps_urls = []
         if is_index:
             logger.info("Sitemap %s is index", self.sitemap_url)
-            for subsitemap_url in self._extract_urls(sitemap_content):
-                subsitemap_resp = http_client.get(subsitemap_url)
-                subsitemap_resp.raise_for_status()
-                subsitemap_content = subsitemap_resp.content
-                sitemaps_urls.extend(self._extract_urls(subsitemap_content))
+            sitemaps_urls.extend(self._extract_urls(sitemap_content))
         else:
             logger.info("Sitemap %s is not index", self.sitemap_url)
             sitemaps_urls.append(self.sitemap_url)
@@ -78,9 +74,10 @@ class SiteMapURLCollector(URLCollector):
         page_urls = []
 
         for sm_url in sitemaps_urls:
+            logger.info("Get URLs from %s", sm_url)
             pages_container = http_client.get(sm_url)
             pages_container.raise_for_status()
-            pages_container_content = pages_container.content
+            pages_container_content = pages_container.content.decode("utf-8")
             page_urls.extend(self._extract_urls(pages_container_content))
 
         logger.info("We found %s urls", len(page_urls))

--- a/welearn_datastack/collectors/sitemap_collector.py
+++ b/welearn_datastack/collectors/sitemap_collector.py
@@ -1,0 +1,89 @@
+import logging
+import os
+from typing import List
+
+from welearn_database.data.models import Corpus, WeLearnDocument
+
+from welearn_datastack.collectors.helpers.feed_helpers import (
+    extracted_url_to_url_datastore,
+)
+from welearn_datastack.data.url_collector import URLCollector
+from welearn_datastack.modules.xml_extractor import XMLExtractor
+from welearn_datastack.utils_.http_client_utils import get_new_https_session
+
+log_level: int = logging.getLevelName(os.getenv("LOG_LEVEL", "INFO"))
+log_format: str = os.getenv(
+    "LOG_FORMAT", "[%(asctime)s][%(name)s][%(levelname)s] - %(message)s"
+)
+
+if not isinstance(log_level, int):
+    raise ValueError("Log level is not recognized : '%s'", log_level)
+
+logging.basicConfig(
+    level=logging.getLevelName(log_level),
+    format=log_format,
+)
+logger = logging.getLogger(__name__)
+
+
+class SiteMapURLCollector(URLCollector):
+    def __init__(
+        self,
+        sitemap_url: str,
+        corpus: Corpus,
+    ) -> None:
+        self.sitemap_url = sitemap_url
+        self.corpus = corpus
+
+    @staticmethod
+    def _is_sitemap_index(sitemap_to_test: str) -> bool:
+        extractor = XMLExtractor(sitemap_to_test)
+        index = extractor.extract_content("sitemapindex")
+
+        if index:
+            return True
+        return False
+
+    @staticmethod
+    def _extract_urls(sitemap_to_test: str) -> list[str]:
+        ret = []
+        extractor = XMLExtractor(sitemap_to_test)
+        for loc in extractor.extract_content("loc"):
+            ret.append(loc.content)
+        return ret
+
+    def collect(self) -> List[WeLearnDocument]:
+        logger.info("Start sitemap url collector")
+        http_client = get_new_https_session()
+
+        sitemap_resp = http_client.get(self.sitemap_url)
+        sitemap_resp.raise_for_status()
+        sitemap_content = sitemap_resp.content
+
+        is_index = self._is_sitemap_index(sitemap_content)
+        logger.info("Sitemap is index ? : %s", is_index)
+
+        sitemaps_urls = []
+        if is_index:
+            logger.info("Sitemap %s is index", self.sitemap_url)
+            for subsitemap_url in self._extract_urls(sitemap_content):
+                subsitemap_resp = http_client.get(subsitemap_url)
+                subsitemap_resp.raise_for_status()
+                subsitemap_content = subsitemap_resp.content
+                sitemaps_urls.extend(self._extract_urls(subsitemap_content))
+        else:
+            logger.info("Sitemap %s is not index", self.sitemap_url)
+            sitemaps_urls.append(self.sitemap_url)
+
+        page_urls = []
+
+        for sm_url in sitemaps_urls:
+            pages_container = http_client.get(sm_url)
+            pages_container.raise_for_status()
+            pages_container_content = pages_container.content
+            page_urls.extend(self._extract_urls(pages_container_content))
+
+        logger.info("We found %s urls", len(page_urls))
+        ret = extracted_url_to_url_datastore(urls=page_urls, corpus=self.corpus)
+
+        return ret

--- a/welearn_datastack/collectors/sitemap_collector.py
+++ b/welearn_datastack/collectors/sitemap_collector.py
@@ -40,9 +40,7 @@ class SiteMapURLCollector(URLCollector):
         extractor = XMLExtractor(sitemap_to_test)
         index = extractor.extract_content("sitemapindex")
 
-        if index:
-            return True
-        return False
+        return bool(index)
 
     @staticmethod
     def _extract_urls(sitemap_to_test: str) -> list[str]:

--- a/welearn_datastack/nodes_workflow/URLCollectors/node_sitemap_collect.py
+++ b/welearn_datastack/nodes_workflow/URLCollectors/node_sitemap_collect.py
@@ -48,12 +48,12 @@ if __name__ == "__main__":
     if corpus is None:
         raise ValueError(f"Corpus {corpus_name} not found")
 
-    atom_collector = SiteMapURLCollector(
+    sitemap_collector = SiteMapURLCollector(
         sitemap_url=sitemap_url,
         corpus=corpus,
     )
 
-    urls = atom_collector.collect()
+    urls = sitemap_collector.collect()
 
     logger.info("URLs retrieved : '%s'", len(urls))
 

--- a/welearn_datastack/nodes_workflow/URLCollectors/node_sitemap_collect.py
+++ b/welearn_datastack/nodes_workflow/URLCollectors/node_sitemap_collect.py
@@ -62,4 +62,4 @@ if __name__ == "__main__":
         urls=urls,
     )
 
-    logger.info("Atom collector ended")
+    logger.info("Sitemap collector ended")

--- a/welearn_datastack/nodes_workflow/URLCollectors/node_sitemap_collect.py
+++ b/welearn_datastack/nodes_workflow/URLCollectors/node_sitemap_collect.py
@@ -1,0 +1,65 @@
+import logging
+import os
+
+from dotenv import load_dotenv
+from welearn_database.data.models import Corpus
+
+from welearn_datastack.collectors.sitemap_collector import SiteMapURLCollector
+from welearn_datastack.nodes_workflow.URLCollectors.nodes_helpers.collect import (
+    insert_urls,
+)
+from welearn_datastack.utils_.database_utils import create_db_session
+from welearn_datastack.utils_.virtual_environement_utils import load_dotenv_local
+
+log_level: int = logging.getLevelName(os.getenv("LOG_LEVEL", "INFO"))
+log_format: str = os.getenv(
+    "LOG_FORMAT", "[%(asctime)s][%(name)s][%(levelname)s] - %(message)s"
+)
+
+if not isinstance(log_level, int):
+    raise ValueError("Log level is not recognized : '%s'", log_level)
+
+logging.basicConfig(
+    level=logging.getLevelName(log_level),
+    format=log_format,
+)
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    logger.info("Sitemap collector starting...")
+    load_dotenv_local()
+    session = create_db_session()
+    sitemap_url = os.getenv("SITEMAP_URL")
+
+    corpus_name = os.getenv("CORPUS_NAME")
+
+    if not sitemap_url:
+        raise ValueError("SITEMAP_URL is not defined")
+
+    if not corpus_name:
+        raise ValueError("CORPUS_NAME is not defined")
+
+    corpus: Corpus | None = (
+        session.query(Corpus).filter_by(source_name=corpus_name).one_or_none()
+    )
+
+    if corpus is None:
+        raise ValueError(f"Corpus {corpus_name} not found")
+
+    atom_collector = SiteMapURLCollector(
+        sitemap_url=sitemap_url,
+        corpus=corpus,
+    )
+
+    urls = atom_collector.collect()
+
+    logger.info("URLs retrieved : '%s'", len(urls))
+
+    insert_urls(
+        session=session,
+        urls=urls,
+    )
+
+    logger.info("Atom collector ended")


### PR DESCRIPTION
This pull request introduces a new sitemap URL collector to the project, enabling the automated extraction and ingestion of URLs from website sitemaps. The main changes include implementing the sitemap collector logic, integrating it as a new workflow template, and providing comprehensive tests.

**New Sitemap Collector Implementation and Integration:**

* Added a new `SiteMapURLCollector` class in `sitemap_collector.py` that fetches and parses sitemap XML files (including sitemap indexes), extracts URLs, and stores them in the database.
* Implemented a new workflow node entrypoint `node_sitemap_collect.py` to run the sitemap collection as a standalone process, reading configuration from environment variables and handling database insertion.
* Added a new Argo workflow template (`collect-sitemap`) to `workflow-template.yaml` and integrated it into the cron workflow for scheduled collection (including a job for `notre-environnement.gouv.fr`). [[1]](diffhunk://#diff-8f555b73600a29f609d3cf02f30db402d526e2ead1c54c22c0dd9bb5137672faR498-R541) [[2]](diffhunk://#diff-d1d02405646a6b92835c108eaecf74b73ec632084b87c8a063d585517d2da73bR373-R383)

**Testing:**

* Added comprehensive unit tests for the sitemap collector, covering sitemap index parsing, URL extraction, error handling, and integration with the database layer.

**Workflow Template Adjustments:**

* Minor formatting and whitespace changes in the workflow templates to improve readability. [[1]](diffhunk://#diff-8f555b73600a29f609d3cf02f30db402d526e2ead1c54c22c0dd9bb5137672faR124) [[2]](diffhunk://#diff-8f555b73600a29f609d3cf02f30db402d526e2ead1c54c22c0dd9bb5137672faL463)